### PR TITLE
Optimizations - Bug Fixes - Memory Safety

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -272,7 +272,20 @@ bool OMW::Engine::frame(unsigned frameNumber, float frametime)
                 {
                     double hours = (frametime * mWorld->getTimeManager()->getGameTimeScale()) / 3600.0;
                     mWorld->advanceTime(hours, true);
+#ifdef __vita__
+                    // rechargeItems iterates every NPC/Creature/Container in
+                    // every active cell each frame. Recharge math is
+                    // FPS-invariant; throttle to ~4 Hz with accumulated dt.
+                    static float s_rechargeAccum = 0.f;
+                    s_rechargeAccum += frametime;
+                    if (s_rechargeAccum >= 0.25f)
+                    {
+                        mWorld->rechargeItems(s_rechargeAccum, true);
+                        s_rechargeAccum = 0.f;
+                    }
+#else
                     mWorld->rechargeItems(frametime, true);
+#endif
                 }
             }
         }

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1012,7 +1012,21 @@ namespace MWGui
             = MWBase::Environment::get().getStateManager()->getState() != MWBase::StateManager::State_NoGame;
 
         if (gameRunning)
+        {
+#ifdef __vita__
+            // Map widget refresh throttled to ~8 Hz on Vita. Per-frame
+            // updateMap costs 0.5-1.5 ms iterating maps + magic markers.
+            static float s_mapAccum = 0.f;
+            s_mapAccum += frameDuration;
+            if (s_mapAccum >= 0.125f)
+            {
+                s_mapAccum = 0.f;
+                updateMap();
+            }
+#else
             updateMap();
+#endif
+        }
 
         if (!mGuiModes.empty())
         {

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1590,6 +1590,20 @@ namespace MWMechanics
                     const bool cellChanged = worldScene->hasCellChanged();
                     const MWWorld::Ptr actorPtr = actor.getPtr(); // make a copy of the map key to avoid it being
                                                                   // invalidated when the player teleports
+#ifdef __vita__
+                    // updateActor (awareness/regen/active-spell tick) and the
+                    // VFX walk are out-of-band for actors outside the AI
+                    // processing radius; vanilla relies on these only for
+                    // actors the player is interacting with. Skipping for
+                    // distant NPCs saves ~3-6 ms/frame in dense areas.
+                    if (inProcessingRange || isPlayer)
+                    {
+                        updateActor(actorPtr, duration);
+                        ctrl.updateContinuousVfx();
+                        if (!cellChanged && worldScene->hasCellChanged())
+                            return;
+                    }
+#else
                     updateActor(actorPtr, duration);
 
                     // Looping magic VFX update
@@ -1604,6 +1618,7 @@ namespace MWMechanics
                         return; // for now abort update of the old cell when cell changes by teleportation magic effect
                                 // a better solution might be to apply cell changes at the end of the frame
                     }
+#endif
                     if (aiActive && inProcessingRange)
                     {
 #ifdef __vita__

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -23,6 +23,20 @@
 
 namespace MWRender
 {
+#ifdef __vita__
+    // NPC movement inside a cell calls setPosition() on each PAT, which dirties
+    // the parent cell-group's bound and forces an O(N children) recompute the
+    // next time any system reads it (cull, light intersection). Returning a
+    // huge fixed sphere short-circuits this — the actual children still cull
+    // individually.
+    struct VitaCellBoundCallback : public osg::Node::ComputeBoundingSphereCallback
+    {
+        osg::BoundingSphere computeBound(const osg::Node&) const override
+        {
+            return osg::BoundingSphere(osg::Vec3(0, 0, 0), 1.0e6f);
+        }
+    };
+#endif
 
     Objects::Objects(Resource::ResourceSystem* resourceSystem, const osg::ref_ptr<osg::Group>& rootNode,
         SceneUtil::UnrefQueue& unrefQueue)
@@ -52,6 +66,9 @@ namespace MWRender
         {
             cellnode = new osg::Group;
             cellnode->setName("Cell Root");
+#ifdef __vita__
+            cellnode->setComputeBoundingSphereCallback(new VitaCellBoundCallback);
+#endif
             mRootNode->addChild(cellnode);
             mCellSceneNodes[ptr.getCell()] = cellnode;
         }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -1097,6 +1097,11 @@ namespace MWRender
             mPostProcessor->getStateUpdater()->setIsWaterEnabled(enabled);
     }
 
+    void RenderingManager::setWaterCell(const MWWorld::CellStore* store)
+    {
+        mWater->changeCell(store);
+    }
+
     void RenderingManager::setWaterHeight(float height)
     {
         mWater->setCullCallback(mTerrain->getHeightCullCallback(height, Mask_Water));

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -169,6 +169,11 @@ namespace MWRender
 
         void setWaterEnabled(bool enabled);
         void setWaterHeight(float level);
+        // Re-anchor the water plane to a cell. Normally done implicitly via
+        // addCell() at cell-load time; needed explicitly on Vita when the
+        // keep-came-from path persists exterior cells across an interior visit
+        // (the cell isn't re-added on exit so addCell never fires).
+        void setWaterCell(const MWWorld::CellStore* store);
 
         /// Take a screenshot of w*h onto the given image, not including the GUI.
         void screenshot(osg::Image* image, int w, int h);

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -262,7 +262,13 @@ namespace MWRender
         , mWindSpeed(0.f)
         , mBaseWindSpeed(0.f)
         , mEnabled(true)
+#ifdef __vita__
+        // Sun glare needs the OcclusionQueryNode pipeline, which on vitaGL requires
+        // a GXM scene break + CPU-side pixel readback every frame.
+        , mSunglareEnabled(false)
+#else
         , mSunglareEnabled(true)
+#endif
         , mPrecipitationAlpha(0.f)
         , mDirtyParticlesEffect(false)
     {
@@ -829,9 +835,17 @@ namespace MWRender
         {
             mCloudBlendFactor = std::clamp(weather.mCloudBlendFactor, 0.f, 1.f);
 
-            mCloudUpdater->setOpacity(1.f - mCloudBlendFactor);
+            const float curOpacity = 1.f - mCloudBlendFactor;
+            mCloudUpdater->setOpacity(curOpacity);
             mNextCloudUpdater->setOpacity(mCloudBlendFactor);
+#ifdef __vita__
+            // A full-sky alpha-blended quad at near-zero opacity costs ~470k
+            // blended fragments per frame for visually nothing — skip the draw.
+            mCloudMesh->setNodeMask(curOpacity > 0.02f ? ~0u : 0);
+            mNextCloudMesh->setNodeMask(mCloudBlendFactor > 0.02f ? ~0u : 0);
+#else
             mNextCloudMesh->setNodeMask(mCloudBlendFactor > 0.f ? ~0u : 0);
+#endif
         }
 
         if (mCloudColour != weather.mFogColor)

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -866,6 +866,12 @@ namespace MWRender
             mAtmosphereUpdater->setEmissionColor(mSkyColour);
             mMasser->setAtmosphereColor(mSkyColour);
             mSecunda->setAtmosphereColor(mSkyColour);
+#ifdef __vita__
+            // Same logic as the cloud opacity gate: a near-transparent
+            // full-sky alpha-blended quad costs ~470k blended fragments and
+            // contributes nothing visible — skip the draw.
+            mAtmosphereDay->setNodeMask(mSkyColour.a() > 0.02f ? ~0u : 0);
+#endif
         }
 
         if (mFogColour != weather.mFogColor)

--- a/apps/openmw/mwrender/skyutil.cpp
+++ b/apps/openmw/mwrender/skyutil.cpp
@@ -807,6 +807,13 @@ namespace MWRender
         osg::ref_ptr<osg::ColorMask> colormask = new osg::ColorMask(0, 0, 0, 0);
         stateset->setAttributeAndModes(colormask);
         sceneManager.setUpNormalsRTForStateSet(stateset, false);
+#ifdef __vita__
+        // Skip the OQ pipeline on Vita. vitaGL's GL_SAMPLES_PASSED requires a
+        // GXM scene break + CPU-side pixel-readback round trip, costing 3-6 ms
+        // outdoors. The visible flash/glare are also masked off via
+        // SkyManager::mSunglareEnabled defaulting to false on Vita.
+        queryNode->setNodeMask(0);
+#endif
         mTransform->addChild(queryNode);
 
         mOcclusionQueryVisiblePixels = createOcclusionQueryNode(queryNode, true);

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -37,7 +37,13 @@ namespace MWSound
 {
     namespace
     {
+#ifdef __vita__
+        // Vita: 3D sound localization at 15 Hz is imperceptible and saves
+        // ~0.4-0.8 ms/frame on the main thread vs. the default 30 Hz.
+        constexpr float sMinUpdateInterval = 1.0f / 15.0f;
+#else
         constexpr float sMinUpdateInterval = 1.0f / 30.0f;
+#endif
         constexpr float sSfxFadeInDuration = 1.0f;
         constexpr float sSfxFadeOutDuration = 1.0f;
         constexpr float sSoundCullDistance = 2000.f;

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -672,6 +672,38 @@ namespace MWWorld
         // Uses a safety callback to skip animated/tracked nodes.
         if (osg::Group* cellRoot = mRendering.getObjects().getCellRoot(&cell))
         {
+            // Pre-pass: each per-object PAT under the cell root carries a
+            // PtrHolder via osg::UserDataContainer. The optimizer's
+            // FLATTEN_STATIC_TRANSFORMS bails on any node with a userdata
+            // container, so it leaves every static under its own PAT — and
+            // MergeGeometry only merges siblings of the SAME group, so it
+            // can never combine across two PATs. Net result: vitaBatchCell
+            // was a near-no-op for cross-object batching.
+            //
+            // Strip the container from STAT-only PATs so flatten + merge can
+            // collapse them into shared-StateSet supergeometries. Doors and
+            // activators (interactive — script can disable/move them) keep
+            // their PtrHolder so they remain individually addressable.
+            std::vector<std::pair<osg::Node*, osg::ref_ptr<osg::UserDataContainer>>> stripped;
+            for (unsigned int i = 0; i < cellRoot->getNumChildren(); ++i)
+            {
+                osg::Node* child = cellRoot->getChild(i);
+                osg::UserDataContainer* udc = child->getUserDataContainer();
+                if (!udc || udc->getNumUserObjects() == 0)
+                    continue;
+                auto* holder = dynamic_cast<MWRender::PtrHolder*>(udc->getUserObject(0));
+                if (!holder)
+                    continue;
+                unsigned int t = holder->mPtr.getType();
+                // Only liberate truly static refs. Doors and activators stay
+                // pinned because gameplay needs to find them by Ptr.
+                if (t == ESM::REC_STAT || t == ESM::REC_STAT4)
+                {
+                    stripped.emplace_back(child, udc);
+                    child->setUserDataContainer(nullptr);
+                }
+            }
+
             struct VitaCanOptimize : public SceneUtil::Optimizer::IsOperationPermissibleForObjectCallback
             {
                 const osg::Group* mCellRoot;
@@ -689,6 +721,7 @@ namespace MWWorld
                         return false;
                     if (node->getDataVariance() == osg::Object::DYNAMIC)
                         return false;
+                    // Doors/activators still carry the PtrHolder; respect that.
                     if (node->getUserDataContainer())
                         return false;
                     if (node->getUpdateCallback())
@@ -708,6 +741,17 @@ namespace MWWorld
                     | SceneUtil::Optimizer::SHARE_DUPLICATE_STATE
                     | SceneUtil::Optimizer::MERGE_GEOMETRY
                     | SceneUtil::Optimizer::VERTEX_POSTTRANSFORM);
+
+            // Best-effort restore: if a stripped PAT survived flattening (e.g.
+            // because it carried a non-flattenable transform), reattach its
+            // userdata so any still-valid Ptr lookup keeps working. PATs that
+            // got flattened away are no longer in the graph; the ref_ptr to
+            // their old userdata simply releases.
+            for (auto& [node, udc] : stripped)
+            {
+                if (node->getNumParents() > 0)
+                    node->setUserDataContainer(udc);
+            }
 
             // Replace OSG's loose bounding-sphere cull with a tight AABB.
             osg::BoundingBox cellAABB = Vita::computeCellAABB(cellRoot);
@@ -1618,6 +1662,40 @@ namespace MWWorld
         CellStore& current = mWorld.getWorldModel().getExterior(playerCellIndex);
         MWBase::Environment::get().getWindowManager()->changeCell(&current);
 
+#ifdef __vita__
+        // Re-assert global water state. With keep-came-from, ring cells stay
+        // Lite across grid changes and the per-cell setWaterEnabled calls in
+        // loadCell* never fire for cells that simply persisted. Worse, the
+        // water plane's anchor position is set by Water::changeCell() inside
+        // addCell() — and addCell() doesn't run for kept cells either, so on
+        // exit from an interior the water plane is stuck at the interior's
+        // (0, 0, mTop) anchor instead of the exterior cell coords.
+        {
+            CellStore* anyWaterCell = nullptr;
+            for (auto* c : mActiveCells)
+            {
+                if (c->getCell()->isExterior() || c->getCell()->hasWater())
+                {
+                    anyWaterCell = c;
+                    break;
+                }
+            }
+            if (anyWaterCell)
+            {
+                const float level = anyWaterCell->getWaterLevel();
+                mRendering.setWaterEnabled(true);
+                mRendering.setWaterHeight(level);
+                mRendering.setWaterCell(&current); // re-anchor plane to player's exterior cell
+                mPhysics->enableWater(level);
+            }
+            else
+            {
+                mRendering.setWaterEnabled(false);
+                mPhysics->disableWater();
+            }
+        }
+#endif
+
         if (changeEvent)
             mCellChanged = true;
 
@@ -1889,18 +1967,54 @@ namespace MWWorld
 
         auto navigatorUpdateGuard = mNavigator.makeUpdateGuard();
 
+#ifdef __vita__
+        // Keep the came-from exterior grid lite-loaded while we're inside the
+        // interior unless memory is genuinely tight. On exit, changeCellGrid's
+        // tier-transition logic promotes the relevant cell straight back to
+        // Full instead of paying a fresh load — turning the most common door-
+        // exit case into a near-zero loading screen.
+        const bool keepExteriors = !Vita::isMemoryPressure(getVitaCellBudgetMB());
+#endif
+
         // unload
         for (auto iter = mActiveCells.begin(); iter != mActiveCells.end();)
         {
             auto* cellToUnload = *iter++;
+#ifdef __vita__
+            if (keepExteriors && cellToUnload->getCell()->isExterior())
+            {
+                // Demote any Full cell so we stop ticking NPCs/scripts/AI on
+                // it while the player is indoors. Lite cells stay as-is.
+                auto tierIt = mCellLoadTiers.find(cellToUnload);
+                if (tierIt != mCellLoadTiers.end() && tierIt->second == CellLoadTier::Full)
+                    demoteCellToLite(*cellToUnload, navigatorUpdateGuard.get());
+                continue;
+            }
+#endif
             unloadCell(cellToUnload, navigatorUpdateGuard.get());
         }
-        assert(mActiveCells.empty());
 
 #ifdef __vita__
-        // Two-step flush: release deferred objects, then evict cache entries
-        mRendering.flushUnrefQueueImmediate();
-        mRendering.getResourceSystem()->clearCache();
+        if (!keepExteriors)
+        {
+            assert(mActiveCells.empty());
+            // Two-step flush: release deferred objects, then evict cache entries
+            mRendering.flushUnrefQueueImmediate();
+            mRendering.getResourceSystem()->clearCache();
+        }
+        else
+        {
+            // Release any unref'd resources from the demote pass, but keep the
+            // shared resource cache warm — we'll need those textures and meshes
+            // on the way back out.
+            mRendering.flushUnrefQueueImmediate();
+            char buf[128];
+            snprintf(buf, sizeof(buf), "changeToInteriorCell: kept %d exterior cell(s) lite-loaded",
+                (int)mActiveCells.size());
+            Vita::breadcrumb(buf);
+        }
+#else
+        assert(mActiveCells.empty());
 #endif
 
         loadingListener->setProgressRange(cell.count());

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -566,14 +566,27 @@ namespace MWWorld
         // Incrementally load deferred ring cells
         processPendingCellLoads();
 
+        // Drain queued cell demotions (cells deferred from interior entry).
+        // Gated on no pending loads inside processPendingDemotions itself.
+        processPendingDemotions();
+
+        // Drain queued cell promotions (cells streaming up Lite→Full when
+        // exiting an interior). Promotion priority is NPCs/creatures first
+        // so the player sees them as soon as possible.
+        processPendingPromotions();
+
         // Memory-pressure watchdog: flush caches when heap is high.
         // Only acts once per threshold crossing to avoid spamming clearCache
         // every frame when all memory is live (active cells, not cached templates).
+        // Trigger at budget - 10 MB (222 MB) instead of budget + 10. Heap is
+        // 272 MB; firing earlier gives 50 MB of headroom to absorb the
+        // typical ~30 MB interior-load + queued unref delta that can push us
+        // past OOM if we wait until budget+10.
         {
             static bool s_cachesFlushed = false;
             int usedMB = Vita::getHeapUsedMB();
             int budget = getVitaCellBudgetMB();
-            if (usedMB > budget + 10 && !s_cachesFlushed)
+            if (usedMB > budget - 10 && !s_cachesFlushed)
             {
                 mRendering.flushUnrefQueueImmediate();
                 mRendering.getResourceSystem()->clearCache();
@@ -585,7 +598,9 @@ namespace MWWorld
                 snprintf(buf, sizeof(buf), "[MemWatchdog] Cache flush at %dMB (budget %dMB)", usedMB, budget);
                 Vita::breadcrumb(buf);
             }
-            else if (usedMB < budget - 10)
+            // Reset further below the trigger so we don't oscillate
+            // on small allocations near the threshold.
+            else if (usedMB < budget - 25)
             {
                 s_cachesFlushed = false; // reset when memory is healthy
                 Vita::replenishEmergencyReserve();
@@ -659,6 +674,19 @@ namespace MWWorld
             std::remove_if(mPendingCellLoads.begin(), mPendingCellLoads.end(),
                 [cell](const PendingCellLoad& p) { return p.cell == cell; }),
             mPendingCellLoads.end());
+        // Drop any pending demote — the cell is being torn down entirely,
+        // no need to demote first. (Removal sequence in unloadCell handles
+        // everything the demote would have done.)
+        mPendingDemotions.erase(
+            std::remove_if(mPendingDemotions.begin(), mPendingDemotions.end(),
+                [cell](const PendingDemotion& pd) { return pd.cell == cell; }),
+            mPendingDemotions.end());
+        // Same for pending promote — the cell is gone, no point streaming
+        // more objects into it.
+        mPendingPromotions.erase(
+            std::remove_if(mPendingPromotions.begin(), mPendingPromotions.end(),
+                [cell](const PendingPromotion& pp) { return pp.cell == cell; }),
+            mPendingPromotions.end());
 #endif
         // Clean up any effects that may have been spawned while unloading all cells
         if (mActiveCells.empty())
@@ -735,12 +763,16 @@ namespace MWWorld
 
             SceneUtil::Optimizer optimizer;
             optimizer.setIsOperationPermissibleForObjectCallback(new VitaCanOptimize(cellRoot));
+            // VERTEX_POSTTRANSFORM (Tipsify-style triangle reorder for vertex-cache
+            // locality) is dropped on Vita: SGX543 is a tile-based deferred renderer
+            // whose vertex throughput is dominated by tile-binning bandwidth, not
+            // post-transform cache locality. The reorder pass is O(triangles) per
+            // geometry — measurable cost for a benefit the hardware barely sees.
             optimizer.optimize(cellRoot,
                 SceneUtil::Optimizer::FLATTEN_STATIC_TRANSFORMS
                     | SceneUtil::Optimizer::REMOVE_REDUNDANT_NODES
                     | SceneUtil::Optimizer::SHARE_DUPLICATE_STATE
-                    | SceneUtil::Optimizer::MERGE_GEOMETRY
-                    | SceneUtil::Optimizer::VERTEX_POSTTRANSFORM);
+                    | SceneUtil::Optimizer::MERGE_GEOMETRY);
 
             // Best-effort restore: if a stripped PAT survived flattening (e.g.
             // because it carried a non-flattenable transform), reattach its
@@ -1124,53 +1156,117 @@ namespace MWWorld
         }
     }
 
+    namespace
+    {
+        // Lower number = higher priority (streamed in first).
+        int promotionPriority(unsigned int recType)
+        {
+            switch (recType)
+            {
+                case ESM::REC_NPC_:
+                case ESM::REC_CREA:
+                case ESM::REC_LEVC:
+                case ESM::REC_NPC_4:
+                case ESM::REC_CREA4:
+                    return 0; // visible/interactable creatures first
+                case ESM::REC_LIGH:
+                case ESM::REC_LIGH4:
+                    return 1; // light sources second — affects visual feel
+                case ESM::REC_CONT:
+                case ESM::REC_CONT4:
+                    return 2; // containers (openable) third
+                default:
+                    return 3; // loose clutter (books, weapons, ingredients, etc.)
+            }
+        }
+    }
     void Scene::promoteCellToFull(CellStore& cell, Loading::Listener* loadingListener,
         const DetourNavigator::UpdateGuard* navigatorUpdateGuard)
     {
         VITA_CRUMB("promoteCellToFull() enter");
-        // Release unref'd demoted-cell resources but keep the shared cache.
+        // If this cell was waiting to be demoted, the demote is now moot —
+        // the cell is becoming Full again. Just drop the pending entry.
+        // The cell is still in Full tier (demote never ran), so the
+        // promotion below is a no-op for objects (they're already in scene)
+        // but still re-establishes water + script registration in the
+        // path below.
+        {
+            auto it = std::find_if(mPendingDemotions.begin(), mPendingDemotions.end(),
+                [&cell](const PendingDemotion& pd) { return pd.cell == &cell; });
+            if (it != mPendingDemotions.end())
+            {
+                mPendingDemotions.erase(it);
+                VITA_CRUMB("promoteCellToFull: cancelled pending demote");
+                // Cell is still Full → InsertVisitorFiltered below will skip
+                // every object (they have base nodes), which is what we want.
+                // Local scripts are still registered. Just update tier and return.
+                mCellLoadTiers[&cell] = CellLoadTier::Full;
+                return;
+            }
+        }
+        // Already pending? Don't queue twice.
+        if (std::find_if(mPendingPromotions.begin(), mPendingPromotions.end(),
+                [&cell](const PendingPromotion& pp) { return pp.cell == &cell; })
+            != mPendingPromotions.end())
+        {
+            return;
+        }
         mRendering.flushUnrefQueueImmediate();
         {
             char buf[128];
-            snprintf(buf, sizeof(buf), "Promote cell %d,%d LITE->FULL, heap %dMB (post-flush)",
-                cell.getCell()->getGridX(), cell.getCell()->getGridY(), Vita::getHeapUsedMB());
+            snprintf(buf, sizeof(buf), "Promote cell %d,%d LITE->FULL queued (async)",
+                cell.getCell()->getGridX(), cell.getCell()->getGridY());
             Vita::breadcrumb(buf);
         }
 
-        // Register local scripts (was skipped during lite load)
-        mWorld.getLocalScripts().addCell(&cell);
-
-        // Respawn NPCs/creatures
-        cell.respawn();
-
-        // Insert only NON-lite objects (NPCs, creatures, containers, lights, clutter)
-        // Inverse filter: skip types that were already loaded in lite mode
-        const bool isInterior = !cell.isExterior();
-        InsertVisitorFiltered insertVisitor(cell, loadingListener,
-            [](unsigned int type) { return !isLiteType(type); });
-        cell.forEach(insertVisitor);
-        insertVisitor.insert(
-            [&](const MWWorld::Ptr& ptr) { addObject(ptr, mWorld, mPagedRefs, *mPhysics, mRendering); });
-        insertVisitor.insert([&](const MWWorld::Ptr& ptr) {
-            addObject(ptr, mWorld, *mPhysics, mLowestPoint, isInterior, mNavigator, navigatorUpdateGuard);
-        });
-
-        // No re-batching needed — statics were already batched during lite load.
-        // Newly added objects (NPCs, creatures) are dynamic and can't be batched.
-
+        // Flip tier to Full immediately. Gameplay code keying off tier sees
+        // this cell as fully active straight away; the actual object
+        // streaming happens in processPendingPromotions over the next few
+        // frames. Eliminates the 200-600 ms hang during fade-out.
         mCellLoadTiers[&cell] = CellLoadTier::Full;
 
+        PendingPromotion pp;
+        pp.cell = &cell;
+        mPendingPromotions.push_back(std::move(pp));
+    }
+
+    void Scene::removeNonLiteObject(const MWWorld::Ptr& ptr,
+        const DetourNavigator::UpdateGuard* navigatorUpdateGuard)
+    {
+        MWBase::Environment::get().getMechanicsManager()->remove(ptr, false);
+        MWBase::Environment::get().getLuaManager()->objectRemovedFromScene(ptr);
+
+        if (const auto object = mPhysics->getObject(ptr))
         {
-            char buf[128];
-            snprintf(buf, sizeof(buf), "Promote cell %d,%d done, heap %dMB",
-                cell.getCell()->getGridX(), cell.getCell()->getGridY(), Vita::getHeapUsedMB());
-            Vita::breadcrumb(buf);
+            if (object->getShapeInstance()->mVisualCollisionType == Resource::VisualCollisionType::None)
+                mNavigator.removeObject(DetourNavigator::ObjectId(object), navigatorUpdateGuard);
+            mPhysics->remove(ptr);
         }
+        else if (mPhysics->getActor(ptr))
+        {
+            mNavigator.removeAgent(mWorld.getPathfindingAgentBounds(ptr));
+            mRendering.removeActorPath(ptr);
+            mPhysics->remove(ptr);
+        }
+
+        mRendering.removeObject(ptr);
+        if (ptr.getClass().isActor())
+            mRendering.removeWaterRippleEmitter(ptr);
+
+        ptr.getRefData().setBaseNode(nullptr);
     }
 
     void Scene::demoteCellToLite(CellStore& cell,
         const DetourNavigator::UpdateGuard* navigatorUpdateGuard)
     {
+        // If a promote is still streaming into this cell, drop it. The cell
+        // is reverting to Lite — any unstreamed objects were going to be
+        // inserted just to be removed below.
+        mPendingPromotions.erase(
+            std::remove_if(mPendingPromotions.begin(), mPendingPromotions.end(),
+                [&cell](const PendingPromotion& pp) { return pp.cell == &cell; }),
+            mPendingPromotions.end());
+
         VITA_CRUMB("demoteCellToLite() enter");
         {
             char buf[128];
@@ -1187,41 +1283,10 @@ namespace MWWorld
             return true;
         });
 
-        // Remove each non-lite object from the scene
         for (auto& ptr : toRemove)
-        {
-            // Remove from mechanics manager
-            MWBase::Environment::get().getMechanicsManager()->remove(ptr, false);
+            removeNonLiteObject(ptr, navigatorUpdateGuard);
 
-            // Notify Lua
-            MWBase::Environment::get().getLuaManager()->objectRemovedFromScene(ptr);
-
-            // Remove from physics + navigator
-            if (const auto object = mPhysics->getObject(ptr))
-            {
-                if (object->getShapeInstance()->mVisualCollisionType == Resource::VisualCollisionType::None)
-                    mNavigator.removeObject(DetourNavigator::ObjectId(object), navigatorUpdateGuard);
-                mPhysics->remove(ptr);
-            }
-            else if (mPhysics->getActor(ptr))
-            {
-                mNavigator.removeAgent(mWorld.getPathfindingAgentBounds(ptr));
-                mRendering.removeActorPath(ptr);
-                mPhysics->remove(ptr);
-            }
-
-            // Remove rendering
-            mRendering.removeObject(ptr);
-            if (ptr.getClass().isActor())
-                mRendering.removeWaterRippleEmitter(ptr);
-
-            // Clear base node so it can be re-added on promotion
-            ptr.getRefData().setBaseNode(nullptr);
-        }
-
-        // Clear local scripts for this cell
         mWorld.getLocalScripts().clearCell(&cell);
-
         mCellLoadTiers[&cell] = CellLoadTier::Lite;
 
         {
@@ -1231,6 +1296,288 @@ namespace MWWorld
                 (int)toRemove.size(), Vita::getHeapUsedMB());
             Vita::breadcrumb(buf);
         }
+    }
+
+    void Scene::processPendingDemotions()
+    {
+        if (mPendingDemotions.empty())
+            return;
+        // Don't demote while we're already paying for ring-cell streaming
+        // — they share the main thread budget.
+        if (!mPendingCellLoads.empty())
+            return;
+        if (Vita::isMemoryPressure(getVitaCellBudgetMB()))
+            return;
+
+        PendingDemotion& pd = mPendingDemotions.front();
+        if (pd.cell == nullptr)
+        {
+            mPendingDemotions.erase(mPendingDemotions.begin());
+            return;
+        }
+
+        if (!pd.collected)
+        {
+            pd.cell->forEach([&](const MWWorld::Ptr& ptr) {
+                if (!isLiteType(ptr.getType()) && ptr.getRefData().getBaseNode())
+                    pd.toRemove.push_back(ptr);
+                return true;
+            });
+            pd.collected = true;
+            return; // give the next frame for the actual removes
+        }
+
+        auto navigatorUpdateGuard = mNavigator.makeUpdateGuard();
+        int budget = kDemotionsPerFrame;
+        while (pd.nextIdx < static_cast<int>(pd.toRemove.size()) && budget > 0)
+        {
+            MWWorld::Ptr& ptr = pd.toRemove[pd.nextIdx++];
+            if (!ptr.getRefData().getBaseNode())
+                continue; // already removed by another path
+            removeNonLiteObject(ptr, navigatorUpdateGuard.get());
+            --budget;
+        }
+
+        if (pd.nextIdx >= static_cast<int>(pd.toRemove.size()))
+        {
+            CellStore* cell = pd.cell;
+            mWorld.getLocalScripts().clearCell(cell);
+            mCellLoadTiers[cell] = CellLoadTier::Lite;
+            {
+                char buf[128];
+                snprintf(buf, sizeof(buf), "Async demote (%d,%d) complete, heap %dMB",
+                    cell->getCell()->getGridX(), cell->getCell()->getGridY(),
+                    Vita::getHeapUsedMB());
+                Vita::breadcrumb(buf);
+            }
+            mPendingDemotions.erase(mPendingDemotions.begin());
+        }
+    }
+
+    void Scene::flushPendingDemotion(CellStore* cell)
+    {
+        auto it = std::find_if(mPendingDemotions.begin(), mPendingDemotions.end(),
+            [cell](const PendingDemotion& pd) { return pd.cell == cell; });
+        if (it == mPendingDemotions.end())
+            return;
+
+        VITA_CRUMB("flushPendingDemotion: forcing sync drain");
+
+        auto navigatorUpdateGuard = mNavigator.makeUpdateGuard();
+        if (!it->collected)
+        {
+            cell->forEach([&](const MWWorld::Ptr& ptr) {
+                if (!isLiteType(ptr.getType()) && ptr.getRefData().getBaseNode())
+                    it->toRemove.push_back(ptr);
+                return true;
+            });
+            it->collected = true;
+        }
+        while (it->nextIdx < static_cast<int>(it->toRemove.size()))
+        {
+            MWWorld::Ptr& ptr = it->toRemove[it->nextIdx++];
+            if (!ptr.getRefData().getBaseNode())
+                continue;
+            removeNonLiteObject(ptr, navigatorUpdateGuard.get());
+        }
+        mWorld.getLocalScripts().clearCell(cell);
+        mCellLoadTiers[cell] = CellLoadTier::Lite;
+        mPendingDemotions.erase(it);
+    }
+
+    void Scene::processPendingPromotions()
+    {
+        if (mPendingPromotions.empty())
+            return;
+        if (Vita::isMemoryPressure(getVitaCellBudgetMB()))
+            return;
+
+        PendingPromotion& pp = mPendingPromotions.front();
+        if (pp.cell == nullptr)
+        {
+            mPendingPromotions.erase(mPendingPromotions.begin());
+            return;
+        }
+        CellStore& cell = *pp.cell;
+
+        // Step 1: register local scripts
+        if (!pp.scriptsRegistered)
+        {
+            mWorld.getLocalScripts().addCell(&cell);
+            pp.scriptsRegistered = true;
+            return; // give the next frame for respawn
+        }
+
+        // Step 2: respawn
+        if (!pp.respawnDone)
+        {
+            cell.respawn();
+            pp.respawnDone = true;
+            return;
+        }
+
+        // Step 3: collect non-lite refs once, sorted by priority
+        if (!pp.collected)
+        {
+            cell.forEach([&](const MWWorld::Ptr& ptr) {
+                if (!isLiteType(ptr.getType()))
+                    pp.toInsert.push_back(ptr);
+                return true;
+            });
+            std::stable_sort(pp.toInsert.begin(), pp.toInsert.end(),
+                [](const MWWorld::Ptr& a, const MWWorld::Ptr& b) {
+                    return promotionPriority(a.getType()) < promotionPriority(b.getType());
+                });
+            pp.collected = true;
+            {
+                char buf[128];
+                snprintf(buf, sizeof(buf), "[Promote] cell (%d,%d) %d non-lite refs collected",
+                    cell.getCell()->getGridX(), cell.getCell()->getGridY(),
+                    (int)pp.toInsert.size());
+                Vita::breadcrumb(buf);
+            }
+            return;
+        }
+
+        int budget = kPromotionsPerFrame;
+
+        // Step 4: rendering pass — chunked
+        if (pp.nextRender < static_cast<int>(pp.toInsert.size()))
+        {
+            while (pp.nextRender < static_cast<int>(pp.toInsert.size()) && budget > 0)
+            {
+                if (Vita::isMemoryPressure(getVitaCellBudgetMB()))
+                {
+                    Vita::breadcrumb("[Promote] Mid-burst pause: memory pressure");
+                    return;
+                }
+                MWWorld::Ptr& ptr = pp.toInsert[pp.nextRender++];
+                if (!ptr.mRef->isDeleted() && ptr.getRefData().isEnabled()
+                    && !ptr.getRefData().getBaseNode())
+                {
+                    try
+                    {
+                        addObject(ptr, mWorld, mPagedRefs, *mPhysics, mRendering);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        Log(Debug::Error) << "promote render fail '"
+                                          << ptr.getCellRef().getRefId() << "': " << e.what();
+                    }
+                    --budget;
+                }
+            }
+            return;
+        }
+
+        // Step 5: physics/navigator pass — chunked, fresh guard per frame
+        if (pp.nextPhysics < static_cast<int>(pp.toInsert.size()))
+        {
+            const bool isInterior = !cell.isExterior();
+            auto navigatorUpdateGuard = mNavigator.makeUpdateGuard();
+            while (pp.nextPhysics < static_cast<int>(pp.toInsert.size()) && budget > 0)
+            {
+                MWWorld::Ptr& ptr = pp.toInsert[pp.nextPhysics++];
+                if (!ptr.mRef->isDeleted() && ptr.getRefData().isEnabled()
+                    && ptr.getRefData().getBaseNode())
+                {
+                    try
+                    {
+                        addObject(ptr, mWorld, *mPhysics, mLowestPoint, isInterior,
+                            mNavigator, navigatorUpdateGuard.get());
+                    }
+                    catch (const std::exception& e)
+                    {
+                        Log(Debug::Error) << "promote physics fail '"
+                                          << ptr.getCellRef().getRefId() << "': " << e.what();
+                    }
+                    --budget;
+                }
+            }
+            if (pp.nextPhysics < static_cast<int>(pp.toInsert.size()))
+                return;
+        }
+
+        // Step 6: finalize
+        {
+            char buf[128];
+            snprintf(buf, sizeof(buf), "[Promote] cell (%d,%d) complete (%d objs), heap %dMB",
+                cell.getCell()->getGridX(), cell.getCell()->getGridY(),
+                (int)pp.toInsert.size(), Vita::getHeapUsedMB());
+            Vita::breadcrumb(buf);
+        }
+        mPendingPromotions.erase(mPendingPromotions.begin());
+    }
+
+    void Scene::flushPendingPromotion(CellStore* cell)
+    {
+        auto it = std::find_if(mPendingPromotions.begin(), mPendingPromotions.end(),
+            [cell](const PendingPromotion& pp) { return pp.cell == cell; });
+        if (it == mPendingPromotions.end())
+            return;
+
+        VITA_CRUMB("flushPendingPromotion: forcing sync");
+
+        if (!it->scriptsRegistered)
+        {
+            mWorld.getLocalScripts().addCell(cell);
+            it->scriptsRegistered = true;
+        }
+        if (!it->respawnDone)
+        {
+            cell->respawn();
+            it->respawnDone = true;
+        }
+        if (!it->collected)
+        {
+            cell->forEach([&](const MWWorld::Ptr& ptr) {
+                if (!isLiteType(ptr.getType()))
+                    it->toInsert.push_back(ptr);
+                return true;
+            });
+            // For sync flush we don't need priority sort — just process all.
+            it->collected = true;
+        }
+        while (it->nextRender < static_cast<int>(it->toInsert.size()))
+        {
+            MWWorld::Ptr& ptr = it->toInsert[it->nextRender++];
+            if (!ptr.mRef->isDeleted() && ptr.getRefData().isEnabled()
+                && !ptr.getRefData().getBaseNode())
+            {
+                try
+                {
+                    addObject(ptr, mWorld, mPagedRefs, *mPhysics, mRendering);
+                }
+                catch (const std::exception& e)
+                {
+                    Log(Debug::Error) << "promote(force) render fail '"
+                                      << ptr.getCellRef().getRefId() << "': " << e.what();
+                }
+            }
+        }
+        {
+            const bool isInterior = !cell->isExterior();
+            auto navigatorUpdateGuard = mNavigator.makeUpdateGuard();
+            while (it->nextPhysics < static_cast<int>(it->toInsert.size()))
+            {
+                MWWorld::Ptr& ptr = it->toInsert[it->nextPhysics++];
+                if (!ptr.mRef->isDeleted() && ptr.getRefData().isEnabled()
+                    && ptr.getRefData().getBaseNode())
+                {
+                    try
+                    {
+                        addObject(ptr, mWorld, *mPhysics, mLowestPoint, isInterior,
+                            mNavigator, navigatorUpdateGuard.get());
+                    }
+                    catch (const std::exception& e)
+                    {
+                        Log(Debug::Error) << "promote(force) physics fail '"
+                                          << ptr.getCellRef().getRefId() << "': " << e.what();
+                    }
+                }
+            }
+        }
+        mPendingPromotions.erase(it);
     }
 #endif
 
@@ -1352,6 +1699,11 @@ namespace MWWorld
     {
 #ifdef __vita__
         mPendingCellLoads.clear();
+        // Pending demotions/promotions reference cells that are about to be
+        // unloaded by the loop below. Drop them now to avoid stale
+        // CellStore* in the queue; unloadCell handles full removal anyway.
+        mPendingDemotions.clear();
+        mPendingPromotions.clear();
 #endif
         auto navigatorUpdateGuard = mNavigator.makeUpdateGuard();
         for (auto iter = mActiveCells.begin(); iter != mActiveCells.end();)
@@ -1549,7 +1901,16 @@ namespace MWWorld
                 }
                 else if (!isCenter && tierIt->second == CellLoadTier::Full)
                 {
-                    demoteCellToLite(*activeCell, navigatorUpdateGuard.get());
+                    // If this cell is sitting in mPendingDemotions, take the
+                    // sync path — flushPendingDemotion will finish whatever
+                    // remains. demoteCellToLite would otherwise re-collect
+                    // and double-process the same refs.
+                    auto pendIt = std::find_if(mPendingDemotions.begin(), mPendingDemotions.end(),
+                        [activeCell](const PendingDemotion& pd) { return pd.cell == activeCell; });
+                    if (pendIt != mPendingDemotions.end())
+                        flushPendingDemotion(activeCell);
+                    else
+                        demoteCellToLite(*activeCell, navigatorUpdateGuard.get());
                 }
             }
         }
@@ -1597,8 +1958,6 @@ namespace MWWorld
                 else
                 {
                     loadCellLite(cell, loadingListener, pos, navigatorUpdateGuard.get());
-                    mRendering.flushUnrefQueueImmediate();
-                    mRendering.getResourceSystem()->updateCache(mRendering.getReferenceTime());
                     {
                         char buf[128];
                         snprintf(buf, sizeof(buf), "Loaded cell (%d,%d) LITE sync: heap %dMB",
@@ -1611,6 +1970,18 @@ namespace MWWorld
 #endif
             }
         }
+
+#ifdef __vita__
+        // One flush + cache prune at the end of the grid change instead of
+        // per-ring-cell. With 8 ring cells loading, the previous setup walked
+        // every resource manager 8 times and pruned mSharedStateManager 8
+        // times — measurably slow on grid transitions.
+        if (!cellsPositionsToLoad.empty())
+        {
+            mRendering.flushUnrefQueueImmediate();
+            mRendering.getResourceSystem()->updateCache(mRendering.getReferenceTime());
+        }
+#endif
 
         mNavigator.update(pos, navigatorUpdateGuard.get());
 
@@ -1693,6 +2064,25 @@ namespace MWWorld
                 mRendering.setWaterEnabled(false);
                 mPhysics->disableWater();
             }
+        }
+#endif
+
+#ifdef __vita__
+        // Sync-drain pending demote/promote work before the loading screen
+        // closes. Async streaming during gameplay was leaving the player
+        // "stuck" — main thread budget consumed by the queues for ~1-2s
+        // after the loading screen ended. Cleaner UX: longer load screen
+        // (which already animates progress), then immediate playable state.
+        // The loadingListener is still active here (ScopedLoad in scope above).
+        while (!mPendingPromotions.empty())
+        {
+            flushPendingPromotion(mPendingPromotions.front().cell);
+            loadingListener->increaseProgress(1);
+        }
+        while (!mPendingDemotions.empty())
+        {
+            flushPendingDemotion(mPendingDemotions.front().cell);
+            loadingListener->increaseProgress(1);
         }
 #endif
 
@@ -1973,7 +2363,19 @@ namespace MWWorld
         // tier-transition logic promotes the relevant cell straight back to
         // Full instead of paying a fresh load — turning the most common door-
         // exit case into a near-zero loading screen.
-        const bool keepExteriors = !Vita::isMemoryPressure(getVitaCellBudgetMB());
+        //
+        // Slightly stricter than `isMemoryPressure(budget)`: the interior
+        // load that's about to run can pull in 20-40 MB of new templates on
+        // top of what's already resident. We don't want to OOM when keeping
+        // 9 lite exterior cells stacks with the new interior, but we also
+        // don't want to skip the optimization on routine play sitting at
+        // 180-210 MB. -15 MB headroom from the standard budget (232 MB) puts
+        // the skip threshold at ~217 MB. Routine play stays well under,
+        // gets the fast door. Heavy/late-session memory state falls back to
+        // the safe full-unload path. Watchdog at budget-10 (222 MB) is the
+        // next safety layer if we still grow past the keep-came-from gate.
+        const int keepExteriorsBudget = getVitaCellBudgetMB() - 15;
+        const bool keepExteriors = !Vita::isMemoryPressure(keepExteriorsBudget);
 #endif
 
         // unload
@@ -1983,11 +2385,23 @@ namespace MWWorld
 #ifdef __vita__
             if (keepExteriors && cellToUnload->getCell()->isExterior())
             {
-                // Demote any Full cell so we stop ticking NPCs/scripts/AI on
-                // it while the player is indoors. Lite cells stay as-is.
+                // Queue the demote instead of running it sync. The cell
+                // stays Full briefly while the player is indoors; AI ticks
+                // for its actors get gated out by inProcessingRange anyway.
+                // Eliminates the 100-400 ms hang on every interior entry
+                // that the sync-demote previously caused.
                 auto tierIt = mCellLoadTiers.find(cellToUnload);
                 if (tierIt != mCellLoadTiers.end() && tierIt->second == CellLoadTier::Full)
-                    demoteCellToLite(*cellToUnload, navigatorUpdateGuard.get());
+                {
+                    if (std::find_if(mPendingDemotions.begin(), mPendingDemotions.end(),
+                            [cellToUnload](const PendingDemotion& pd) { return pd.cell == cellToUnload; })
+                        == mPendingDemotions.end())
+                    {
+                        PendingDemotion pd;
+                        pd.cell = cellToUnload;
+                        mPendingDemotions.push_back(std::move(pd));
+                    }
+                }
                 continue;
             }
 #endif
@@ -1998,9 +2412,16 @@ namespace MWWorld
         if (!keepExteriors)
         {
             assert(mActiveCells.empty());
-            // Two-step flush: release deferred objects, then evict cache entries
+            // Memory was tight enough to skip keep-came-from — reach for the
+            // bigger evictions too: shared resource cache + the static
+            // pathgrid/animation caches that bypass OSG expiry. Same set the
+            // memory watchdog uses, run eagerly here so the fresh interior
+            // load lands on a clean slate.
             mRendering.flushUnrefQueueImmediate();
             mRendering.getResourceSystem()->clearCache();
+            MWMechanics::AiPackage::clearPathgridCache();
+            MWRender::clearAnimationModelCache();
+            Vita::breadcrumb("changeToInteriorCell: aggressive flush (mem tight)");
         }
         else
         {
@@ -2050,6 +2471,25 @@ namespace MWWorld
 
         mCellLoaded = true;
         VITA_CRUMB("changeToInteriorCell() cell loaded, fading in");
+
+#ifdef __vita__
+        // Sync-drain any pending demote/promote work before the loading screen
+        // closes. The async streaming would otherwise continue to consume
+        // main-thread budget AFTER the load screen vanishes — the player sees
+        // the screen finish but then can't move because mPendingDemotions /
+        // mPendingPromotions are still being processed by Scene::update.
+        // Better UX: longer loading screen, then immediate playable state.
+        while (!mPendingPromotions.empty())
+        {
+            flushPendingPromotion(mPendingPromotions.front().cell);
+            loadingListener->increaseProgress(1);
+        }
+        while (!mPendingDemotions.empty())
+        {
+            flushPendingDemotion(mPendingDemotions.front().cell);
+            loadingListener->increaseProgress(1);
+        }
+#endif
 
         if (useFading)
             MWBase::Environment::get().getWindowManager()->fadeScreenIn(0.5);

--- a/apps/openmw/mwworld/scene.hpp
+++ b/apps/openmw/mwworld/scene.hpp
@@ -159,7 +159,60 @@ namespace MWWorld
             bool batchingDone = false;
         };
         std::vector<PendingCellLoad> mPendingCellLoads;
-        static constexpr int kObjectsPerFrame = 8;
+        // Per-frame deferred-load budget. Each addObject call costs 0.4-3 ms;
+        // 3 keeps worst-case at ~9 ms (≈30% of a 30 fps budget) instead of
+        // the 24 ms burst that 8 produced. Slower load tail, smoother frames.
+        static constexpr int kObjectsPerFrame = 3;
+
+        // Async demote: a cell that needs to drop Full→Lite (typically the
+        // came-from exterior cells when player enters an interior) is queued
+        // here instead of being synchronously gutted in the unload loop.
+        // Its tier stays Full until processPendingDemotions drains it,
+        // which avoids the 100-400 ms hang on every interior entry.
+        struct PendingDemotion
+        {
+            CellStore* cell = nullptr;
+            std::vector<Ptr> toRemove;
+            int nextIdx = 0;
+            bool collected = false;
+        };
+        std::vector<PendingDemotion> mPendingDemotions;
+        static constexpr int kDemotionsPerFrame = 8;
+
+        // Per-object helper used by demoteCellToLite + the async drainer +
+        // sync flush. Mutates mechanics/lua/physics/navigator/rendering
+        // state and clears the object's base node.
+        void removeNonLiteObject(const Ptr& ptr,
+            const DetourNavigator::UpdateGuard* navigatorUpdateGuard);
+
+        void processPendingDemotions();
+        // Force a single cell's pending demote to complete now — used by
+        // any code path that needs the cell in its final tier (sync
+        // changeCellGrid tier transitions, save serialization, unload).
+        void flushPendingDemotion(CellStore* cell);
+
+        // Async promote — mirror of demote. promoteCellToFull queues a cell
+        // here, flips its tier to Full immediately so subsequent grid
+        // changes don't re-promote, then streams in non-lite objects across
+        // several frames sorted by priority (NPCs/creatures first, lights
+        // second, clutter last). Eliminates the 200-600 ms hang during
+        // fade-out when exiting an interior to a populated exterior cell.
+        struct PendingPromotion
+        {
+            CellStore* cell = nullptr;
+            bool collected = false;
+            bool scriptsRegistered = false;
+            bool respawnDone = false;
+            std::vector<Ptr> toInsert; // priority-sorted
+            int nextRender = 0;
+            int nextPhysics = 0;
+        };
+        std::vector<PendingPromotion> mPendingPromotions;
+        static constexpr int kPromotionsPerFrame = 4;
+
+        void processPendingPromotions();
+        // Force a single cell's pending promote to complete now.
+        void flushPendingPromotion(CellStore* cell);
 
         void insertCellLite(CellStore& cell, Loading::Listener* loadingListener,
             const DetourNavigator::UpdateGuard* navigatorUpdateGuard);

--- a/apps/openmw/vita/VitaInit.cpp
+++ b/apps/openmw/vita/VitaInit.cpp
@@ -1074,8 +1074,22 @@ namespace Vita
 
     int getHeapUsedMB()
     {
-        struct mallinfo mi = mallinfo();
-        return mi.uordblks / (1024 * 1024);
+        // Cache the result. mallinfo() walks the entire allocator's free-list
+        // metadata to compute uordblks — at 200+ MB live with typical heap
+        // fragmentation that's 1-4 ms per call. The watchdog + the deferred-
+        // load chunker call this several times per frame; refreshing once a
+        // second is plenty.
+        static int s_cachedMB = 0;
+        static SceUInt64 s_lastTime = 0;
+        SceUInt64 now = sceKernelGetProcessTimeWide();
+        // sceKernelGetProcessTimeWide returns microseconds.
+        if (s_lastTime == 0 || (now - s_lastTime) > 1000000ULL)
+        {
+            struct mallinfo mi = mallinfo();
+            s_cachedMB = mi.uordblks / (1024 * 1024);
+            s_lastTime = now;
+        }
+        return s_cachedMB;
     }
 
     bool isMemoryPressure(int thresholdMB)

--- a/apps/openmw/vita/VitaInit.cpp
+++ b/apps/openmw/vita/VitaInit.cpp
@@ -1039,7 +1039,23 @@ namespace Vita
         initClocks();
 
         // Initialize vitaGL before SDL_Init so SDL2's video subsystem skips its default init.
-        vglSetParamBufferSize(8 * 1024 * 1024);
+        //
+        // GXM has FOUR independent buffer sizes that all matter for crash-resistance:
+        //  - Parameter buffer   (shader uniforms storage,    default 16 MB) — set via vglSetParamBufferSize
+        //  - VDM ring buffer    (vertex-data-master cmds,    default 128 KB)
+        //  - Vertex ring buffer (per-frame vertex uniforms,  default  2 MB)
+        //  - Fragment ring buf  (per-frame fragment uniforms,default 512 KB)
+        //
+        // sceGxmReserveVertexDefaultUniformBuffer carves from the *vertex ring buffer*,
+        // not the parameter buffer. When that ring fills up, vitaGL's tests.c:280
+        // reserves with no error check and the next sceGxmSetUniformDataF dereferences
+        // garbage → data abort inside SceGxm (R0 = bad CDRAM ptr like 0x70100254).
+        // Observed crash in dense interior cells (Shulk Egg Mine repro). Bumping the
+        // vertex/fragment/VDM rings 2× each. Param buffer left at default 16 MB.
+        vglSetParamBufferSize(16 * 1024 * 1024);
+        vglSetVDMBufferSize(256 * 1024);                  // 128 KB → 256 KB
+        vglSetVertexBufferSize(8 * 1024 * 1024);          //  2 MB → 8 MB (4 MB still crashed; bumped further)
+        vglSetFragmentBufferSize(2 * 1024 * 1024);        // 512 KB → 2 MB
         vglUseTripleBuffering(GL_TRUE);
         vglWaitVblankStart(GL_FALSE);
         vglInitWithCustomSizes(0x100000, 640, 368,

--- a/apps/openmw/vita/settings.cfg
+++ b/apps/openmw/vita/settings.cfg
@@ -16,7 +16,7 @@ camera sensitivity = 0.4
 viewing distance = 2048.0
 field of view = 45.0
 small feature culling = true
-small feature culling pixel size = 4.0
+small feature culling pixel size = 8.0
 reverse z = false
 vita dynamic fog = true
 
@@ -40,7 +40,7 @@ preload num threads = 1
 preload cell cache min = 1
 preload cell cache max = 1
 target framerate = 30
-cache expiry delay = 0.1
+cache expiry delay = 5.0
 pointers cache size = 40
 
 [Map]

--- a/cmake/VitaToolchain.cmake
+++ b/cmake/VitaToolchain.cmake
@@ -15,7 +15,8 @@ include("$ENV{VITASDK}/share/vita.toolchain.cmake")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=cortex-a9 -mfpu=neon" CACHE STRING "" FORCE)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=cortex-a9 -mfpu=neon" CACHE STRING "" FORCE)
 
-# Use -O2 for release on Vita: GCC -Os was leaving real perf on the table in
+# Use -O3 on Vita: -O2 was leaving inliner/vectorizer wins on the table. The
+# previously-explored issues (LTO, fast-math) were unrelated to -O3 itself.
 # NOTE: Do NOT use -flto — causes undefined reference errors for OSG vtable/typeinfo
 # symbols at link time (GCC 10 LTO slim objects in OSG .a libs are incompatible).
 # NOTE: Do NOT use -ffast-math — generates VFPv4 fused multiply-add (vfma) instructions
@@ -24,8 +25,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=cortex-a9 -mfpu=neon" CACHE STRING
 # allow signed-zero and NaN/INF assumptions to unblock NEON auto-vectorization.
 # Deliberately do NOT enable -funsafe-math-optimizations / -ffast-math (vfma).
 set(_VITA_MATH_FLAGS "-fno-math-errno -fno-trapping-math -fno-signed-zeros -ffinite-math-only")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -ftree-vectorize -funroll-loops -fomit-frame-pointer -fno-stack-protector -fipa-icf ${_VITA_MATH_FLAGS}" CACHE STRING "c++ Release flags" FORCE)
-set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG -ftree-vectorize -funroll-loops -fomit-frame-pointer -fno-stack-protector -fipa-icf ${_VITA_MATH_FLAGS}" CACHE STRING "c Release flags" FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -ftree-vectorize -funroll-loops -fomit-frame-pointer -fno-stack-protector -fipa-icf ${_VITA_MATH_FLAGS}" CACHE STRING "c++ Release flags" FORCE)
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -ftree-vectorize -funroll-loops -fomit-frame-pointer -fno-stack-protector -fipa-icf ${_VITA_MATH_FLAGS}" CACHE STRING "c Release flags" FORCE)
 
 # All-static Vita builds have circular deps between libs (vitaGL ↔ SceGxm,
 # freetype ↔ bz2, avformat ↔ avcodec, etc.). Wrap link with --start/end-group

--- a/components/esm3/loadscpt.cpp
+++ b/components/esm3/loadscpt.cpp
@@ -130,7 +130,15 @@ namespace ESM
                 case fourCC("SCVR"):
                     if (!header.has_value())
                         esm.fail("SCVR is placed before SCHD record");
+#ifdef __vita__
+                    // mVarNames is the Bethesda compiler's variable-name table.
+                    // The runtime engine parses var names from mScriptText during
+                    // recompilation — only esmtool/tests read mVarNames. Skip the
+                    // SCVR subrecord on Vita to save a few MB across thousands of scripts.
+                    esm.skipHSub();
+#else
                     loadVarNames(*header, mVarNames, esm);
+#endif
                     break;
                 case fourCC("SCDT"):
                 {
@@ -150,8 +158,17 @@ namespace ESM
                         Log(Debug::Verbose) << ss.str();
                     }
 
+#ifdef __vita__
+                    // mScriptData is the original Bethesda-compiled bytecode. The runtime
+                    // engine never executes it — OpenMW always recompiles from mScriptText
+                    // (see scriptmanagerimp.cpp). Only esmtool/tests read mScriptData.
+                    // Skip on Vita to save ~10-30 MB across a typical mod load
+                    // (thousands of scripts × hundreds-to-thousands of bytes each).
+                    esm.skip(subSize);
+#else
                     mScriptData.resize(subSize);
                     esm.getExact(mScriptData.data(), mScriptData.size());
+#endif
                     break;
                 }
                 case fourCC("SCTX"):

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -478,7 +478,14 @@ namespace Resource
         , mImageManager(imageManager)
         , mNifFileManager(nifFileManager)
         , mBgsmFileManager(bgsmFileManager)
+#ifdef __vita__
+        // Trilinear (LINEAR_MIPMAP_LINEAR) costs ~2× bilinear bandwidth on SGX543
+        // and is imperceptible at 640×368. NEAREST mip selection is the right
+        // default for the platform.
+        , mMinFilter(osg::Texture::LINEAR_MIPMAP_NEAREST)
+#else
         , mMinFilter(osg::Texture::LINEAR_MIPMAP_LINEAR)
+#endif
         , mMagFilter(osg::Texture::LINEAR)
         , mMaxAnisotropy(1.f)
         , mParticleSystemMask(~0u)

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -32,12 +32,12 @@ namespace SceneUtil
 
     void RigGeometry::setSourceGeometry(osg::ref_ptr<osg::Geometry> sourceGeometry)
     {
-        for (unsigned int i = 0; i < 2; ++i)
+        for (unsigned int i = 0; i < kRigBufferSlots; ++i)
             mGeometry[i] = nullptr;
 
         mSourceGeometry = sourceGeometry;
 
-        for (unsigned int i = 0; i < 2; ++i)
+        for (unsigned int i = 0; i < kRigBufferSlots; ++i)
         {
             const osg::Geometry& from = *sourceGeometry;
 
@@ -52,33 +52,27 @@ namespace SceneUtil
 
             osg::Geometry& to = *mGeometry[i];
             to.setSupportsDisplayList(false);
-#ifdef __vita__
-            // On Vita, use client-side arrays for RigGeometry instead of VBOs.
-            // vitaGL's VBO memory can be read by the GPU from the previous frame while
-            // RigGeometry overwrites it with new skinned vertices, causing stretched
-            // triangle artifacts. Client-side arrays get a fresh GPU allocation each draw.
-            to.setUseVertexBufferObjects(false);
-#else
+            // Vita: VBOs are restored, paired with kRigBufferSlots=3 ping-pong
+            // (instead of the 2-slot original) so the GPU is guaranteed to
+            // have finished reading slot N when the CPU writes slot N+3.
+            // The previous client-side fallback re-uploaded all skinned
+            // vertex/normal/tangent data through glVertexAttribPointer every
+            // frame for every NPC — measurable savings on populated cells.
             to.setUseVertexBufferObjects(true);
-#endif
             to.setCullingActive(false); // make sure to disable culling since that's handled by this class
             to.setComputeBoundingBoxCallback(new CopyBoundingBoxCallback());
             to.setComputeBoundingSphereCallback(new CopyBoundingSphereCallback());
 
             // vertices and normals are modified every frame, so we need to deep copy them.
             // assign a dedicated VBO to make sure that modifications don't interfere with source geometry's VBO.
-#ifndef __vita__
             osg::ref_ptr<osg::VertexBufferObject> vbo(new osg::VertexBufferObject);
             vbo->setUsage(GL_DYNAMIC_DRAW_ARB);
-#endif
 
             osg::ref_ptr<osg::Array> vertexArray
                 = static_cast<osg::Array*>(from.getVertexArray()->clone(osg::CopyOp::DEEP_COPY_ALL));
             if (vertexArray)
             {
-#ifndef __vita__
                 vertexArray->setVertexBufferObject(vbo);
-#endif
                 to.setVertexArray(vertexArray);
             }
 
@@ -88,9 +82,7 @@ namespace SceneUtil
                     = static_cast<osg::Array*>(normals->clone(osg::CopyOp::DEEP_COPY_ALL));
                 if (normalArray)
                 {
-#ifndef __vita__
                     normalArray->setVertexBufferObject(vbo);
-#endif
                     to.setNormalArray(normalArray, osg::Array::BIND_PER_VERTEX);
                 }
             }
@@ -100,9 +92,7 @@ namespace SceneUtil
                 mSourceTangents = tangents;
                 osg::ref_ptr<osg::Array> tangentArray
                     = static_cast<osg::Array*>(tangents->clone(osg::CopyOp::DEEP_COPY_ALL));
-#ifndef __vita__
                 tangentArray->setVertexBufferObject(vbo);
-#endif
                 to.setTexCoordArray(7, tangentArray, osg::Array::BIND_PER_VERTEX);
             }
             else
@@ -293,7 +283,7 @@ namespace SceneUtil
             for (unsigned int i = 0; i < getNumParents(); ++i)
                 getParent(i)->dirtyBound();
 
-            for (unsigned int i = 0; i < 2; ++i)
+            for (unsigned int i = 0; i < kRigBufferSlots; ++i)
             {
                 osg::Geometry& geom = *mGeometry[i];
                 static_cast<CopyBoundingBoxCallback*>(geom.getComputeBoundingBoxCallback())->boundingBox = _boundingBox;
@@ -433,7 +423,7 @@ namespace SceneUtil
 
     osg::Geometry* RigGeometry::getGeometry(unsigned int frame) const
     {
-        return mGeometry[frame % 2].get();
+        return mGeometry[frame % kRigBufferSlots].get();
     }
 
 }

--- a/components/sceneutil/riggeometry.hpp
+++ b/components/sceneutil/riggeometry.hpp
@@ -88,7 +88,15 @@ namespace SceneUtil
         void cull(osg::NodeVisitor* nv);
         void updateBounds(osg::NodeVisitor* nv);
 
-        osg::ref_ptr<osg::Geometry> mGeometry[2];
+#ifdef __vita__
+        // 3 slots for triple-buffer safety: vsync-off + vglUseTripleBuffering
+        // means the GPU may still be reading slot[N%K] up to 2 frames later.
+        // K=3 guarantees the slot the CPU is writing isn't being GPU-read.
+        static constexpr int kRigBufferSlots = 3;
+#else
+        static constexpr int kRigBufferSlots = 2;
+#endif
+        osg::ref_ptr<osg::Geometry> mGeometry[kRigBufferSlots];
         osg::Geometry* getGeometry(unsigned int frame) const;
 
         osg::ref_ptr<osg::Geometry> mSourceGeometry;

--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -218,6 +218,33 @@ namespace SDLUtil
                 case SDL_FINGERUP:
                 case SDL_FINGERMOTION:
 #ifdef __vita__
+                    // Back touchpad: left/right halves emulate L2/R2 triggers.
+                    // Margins on the outer edges and the centre seam keep the
+                    // hit zones away from where users naturally rest fingers.
+                    if (evt.tfinger.touchId == 2 && evt.type != SDL_FINGERMOTION && mConListener)
+                    {
+                        constexpr float kEdgeMargin = 0.10f; // left/right outer dead zones
+                        constexpr float kSeamMargin = 0.05f; // centre dead zone (each side)
+                        const float x = evt.tfinger.x;
+                        const bool isL2Zone = (x >= kEdgeMargin && x < 0.5f - kSeamMargin);
+                        const bool isR2Zone = (x > 0.5f + kSeamMargin && x <= 1.0f - kEdgeMargin);
+                        if (isL2Zone || isR2Zone)
+                        {
+                            const bool pressed = (evt.type == SDL_FINGERDOWN);
+                            bool& state = isL2Zone ? mBackTouchL2 : mBackTouchR2;
+                            if (pressed != state)
+                            {
+                                state = pressed;
+                                SDL_ControllerAxisEvent axEvt = {};
+                                axEvt.type = SDL_CONTROLLERAXISMOTION;
+                                axEvt.axis = isL2Zone ? SDL_CONTROLLER_AXIS_TRIGGERLEFT
+                                                      : SDL_CONTROLLER_AXIS_TRIGGERRIGHT;
+                                axEvt.value = pressed ? 32767 : 0;
+                                mConListener->axisMoved(1, axEvt);
+                            }
+                        }
+                        break;
+                    }
                     if (evt.tfinger.touchId == 1)
                     {
                         const bool guiMode = mTouchCursorEnabled && mTouchCursorEnabled();

--- a/components/sdlutil/sdlinputwrapper.hpp
+++ b/components/sdlutil/sdlinputwrapper.hpp
@@ -91,6 +91,10 @@ namespace SDLUtil
         std::function<bool()> mTouchCursorEnabled;
         SDL_FingerID mCursorFingerId = 0;
         bool mCursorFingerActive = false;
+        // Back-touchpad → L2/R2 trigger mapping. State tracked per-half so
+        // pressing both at once (L2+R2) works.
+        bool mBackTouchL2 = false;
+        bool mBackTouchR2 = false;
     public:
         void setTouchCursorEnabledPredicate(std::function<bool()> pred) { mTouchCursorEnabled = std::move(pred); }
     private:

--- a/components/vita/VitaShader.cpp
+++ b/components/vita/VitaShader.cpp
@@ -2,6 +2,7 @@
 
 #include "VitaShader.h"
 
+#include <algorithm>
 #include <string>
 
 #include <osg/Node>
@@ -121,15 +122,13 @@ namespace Vita
         "varying float v_fogFactor;\n"
         "varying float v_skyHorizon;\n"
         "\n"
+        "uniform vec3 u_fogColorEffective;\n"
         "void main() {\n"
         "    vec4 tex = texture2D(diffuseMap, v_texCoord);\n"
         "    vec4 color = vec4(tex.rgb * v_color.rgb, tex.a * v_color.a);\n"
         "    if (color.a < alphaRef) discard;\n"
-        "    float fogLum = max(u_fogColor.r, max(u_fogColor.g, u_fogColor.b));\n"
-        "    float fogGreyMix = 1.0 - smoothstep(0.05, 0.20, fogLum);\n"
-        "    vec3 fogRGB = mix(u_fogColor.rgb, vec3(0.08), fogGreyMix);\n"
-        "    vec3 fogged = mix(fogRGB, color.rgb, v_fogFactor);\n"
-        "    fogged = mix(fogged, fogRGB, v_skyHorizon);\n"
+        "    vec3 fogged = mix(u_fogColorEffective, color.rgb, v_fogFactor);\n"
+        "    fogged = mix(fogged, u_fogColorEffective, v_skyHorizon);\n"
         "    gl_FragColor = vec4(fogged, color.a);\n"
         "}\n";
 
@@ -215,16 +214,14 @@ namespace Vita
         "varying vec4 v_color;\n"
         "varying float v_fogFactor;\n"
         "\n"
+        "uniform vec3 u_fogColorEffective;\n"
         "void main() {\n"
         "    vec4 tex = texture2D(diffuseMap, v_texCoord);\n"
         "    float alpha = 1.0;\n"
         "    if (u_hasBlendMap != 0)\n"
         "        alpha = texture2D(blendMap, v_texCoord2).a;\n"
         "    vec4 color = vec4(tex.rgb * v_color.rgb, alpha);\n"
-        "    float fogLum = max(u_fogColor.r, max(u_fogColor.g, u_fogColor.b));\n"
-        "    float fogGreyMix = 1.0 - smoothstep(0.05, 0.20, fogLum);\n"
-        "    vec3 fogRGB = mix(u_fogColor.rgb, vec3(0.08), fogGreyMix);\n"
-        "    gl_FragColor = mix(vec4(fogRGB, u_fogColor.a), color, v_fogFactor);\n"
+        "    gl_FragColor = mix(vec4(u_fogColorEffective, u_fogColor.a), color, v_fogFactor);\n"
         "}\n";
 
     // VitaTerrainMulti Shaders
@@ -242,6 +239,7 @@ namespace Vita
         "uniform sampler2D u_blend3;\n"
         "uniform int u_numLayers;\n"
         "uniform vec4 u_fogColor;\n"
+        "uniform vec3 u_fogColorEffective;\n"
         "uniform vec3 u_ambient;\n"
         "\n"
         "varying vec2 v_texCoord;\n"
@@ -264,11 +262,7 @@ namespace Vita
         "        color = mix(color, texture2D(u_layer3, v_texCoord).rgb, b3);\n"
         "    }\n"
         "    color *= v_color.rgb;\n"
-
-        "    float fogLum = max(u_fogColor.r, max(u_fogColor.g, u_fogColor.b));\n"
-        "    float fogGreyMix = 1.0 - smoothstep(0.05, 0.20, fogLum);\n"
-        "    vec3 fogRGB = mix(u_fogColor.rgb, vec3(0.08), fogGreyMix);\n"
-        "    gl_FragColor = mix(vec4(fogRGB, u_fogColor.a), vec4(color, 1.0), v_fogFactor);\n"
+        "    gl_FragColor = mix(vec4(u_fogColorEffective, u_fogColor.a), vec4(color, 1.0), v_fogFactor);\n"
         "}\n";
 
     // ==================== Program Creation ====================
@@ -385,6 +379,10 @@ namespace Vita
         ss->addUniform(new osg::Uniform("u_fogStart", 0.f));
         ss->addUniform(new osg::Uniform("u_fogEnd", 2048.f));
         ss->addUniform(new osg::Uniform("u_fogColor", osg::Vec4f(0.7f, 0.7f, 0.7f, 1.f)));
+        // Precomputed fog tint = mix(u_fogColor.rgb, vec3(0.08), greyMix). Keeps
+        // a smoothstep + mix out of the fragment shader; updated CPU-side in
+        // updateSceneUniforms whenever u_fogColor changes.
+        ss->addUniform(new osg::Uniform("u_fogColorEffective", osg::Vec3f(0.7f, 0.7f, 0.7f)));
 
         // Default material uniforms (overridden per-node by applyVitaShader)
         ss->addUniform(new osg::Uniform("u_materialDiffuse", osg::Vec4f(1, 1, 1, 1)));
@@ -457,6 +455,20 @@ namespace Vita
         {
             if (osg::Uniform* u = ss->getUniform("u_fogColor"))
                 u->set(fogColor);
+
+            // Precompute fogRGB = mix(fogColor.rgb, vec3(0.08), 1-smoothstep(0.05,0.20,fogLum))
+            // — was previously per-fragment in 3 shaders.
+            const float fogLum = std::max({ fogColor.r(), fogColor.g(), fogColor.b() });
+            const float t = std::clamp((fogLum - 0.05f) / (0.20f - 0.05f), 0.f, 1.f);
+            const float smoothLum = t * t * (3.f - 2.f * t);
+            const float fogGreyMix = 1.f - smoothLum;
+            const osg::Vec3f fogRGB(
+                fogColor.r() * (1.f - fogGreyMix) + 0.08f * fogGreyMix,
+                fogColor.g() * (1.f - fogGreyMix) + 0.08f * fogGreyMix,
+                fogColor.b() * (1.f - fogGreyMix) + 0.08f * fogGreyMix);
+            if (osg::Uniform* u = ss->getUniform("u_fogColorEffective"))
+                u->set(fogRGB);
+
             s_fogColor = fogColor;
         }
     }

--- a/scripts/vita/build-fast.sh
+++ b/scripts/vita/build-fast.sh
@@ -42,7 +42,7 @@ make -j"$(nproc)" eboot.bin-self
 
 if [ "${WANT_VPK}" -eq 1 ]; then
     echo "=== Building VPK ==="
-    make openmw.vpk-vpk
+    make -j"$(nproc)" openmw.vpk-vpk
 fi
 
 echo ""


### PR DESCRIPTION
Performance improvements, crash fixes, memory optimizations


  - L2/R2 back-touch fix
  - Sun OQ disable
  - Texture filter LINEAR_MIPMAP_NEAREST
  - Toolchain -O3
  - Skeleton SemiActive (reverted to +3 — animation safety)
  - mallinfo cache (1 Hz)
  - Cloud opacity gate
  - Sound update 1/15
  - Map throttle 8 Hz
  - rechargeItems 4 Hz
  - updateActor inProcessingRange gate
  - Fog math hoist to u_fogColorEffective
  - settings.cfg cache expiry 5.0, culling 8.0
  - setWaterEnabled re-assert + setWaterCell API
  - Various MWGui/MWInput/MWWorld bug fixes
  - Async cell-load infrastructure