### PR TITLE
 This round was memory focused. We have been able to

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -7,6 +7,7 @@ if(VITA)
     list(APPEND OPENMW_SOURCES
         vita/VitaInit.cpp
         vita/VitaIme.cpp
+        vita/VitaMemAudit.cpp
     )
 endif()
 

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -630,6 +630,37 @@ namespace MWWorld
         return mHasState;
     }
 
+#ifdef __vita__
+    bool CellStore::isSafeToEvict() const
+    {
+        if (mState != State_Loaded)
+            return false;
+        if (!mHasState)
+            return true;
+        // Evictable iff a save would write nothing for this cell.
+        if (mHasUnrecoverableState || mFogState != nullptr)
+            return false;
+        if (!mMovedHere.empty() || !mMovedToAnotherCell.empty())
+            return false;
+
+        bool clean = true;
+        Misc::tupleForEach(mCellStoreImp->mRefLists, [&clean](const auto& refList) {
+            if (!clean)
+                return;
+            for (const auto& liveCellRef : refList.mList)
+            {
+                if (liveCellRef.mData.hasChanged() || liveCellRef.mRef.hasChanged()
+                    || !liveCellRef.mRef.hasContentFile())
+                {
+                    clean = false;
+                    return;
+                }
+            }
+        });
+        return clean;
+    }
+#endif
+
     bool CellStore::hasId(const ESM::RefId& id) const
     {
         if (mState == State_Unloaded)
@@ -709,6 +740,9 @@ namespace MWWorld
     {
         mWaterLevel = level;
         mHasState = true;
+#ifdef __vita__
+        mHasUnrecoverableState = true;
+#endif
     }
 
     std::size_t CellStore::count() const
@@ -994,6 +1028,9 @@ namespace MWWorld
     void CellStore::loadState(const ESM::CellState& state)
     {
         mHasState = true;
+#ifdef __vita__
+        mHasUnrecoverableState = true;
+#endif
 
         if (!mCellVariant.isExterior() && mCellVariant.hasWater())
             mWaterLevel = state.mWaterLevel;
@@ -1046,6 +1083,9 @@ namespace MWWorld
     void CellStore::readReferences(ESM::ESMReader& reader, GetCellStoreCallback* callback)
     {
         mHasState = true;
+#ifdef __vita__
+        mHasUnrecoverableState = true;
+#endif
 
         while (reader.isNextSub("OBJE"))
         {

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -167,6 +167,11 @@ namespace MWWorld
         bool hasState() const;
         ///< Does this cell have state that needs to be stored in a saved game file?
 
+#ifdef __vita__
+        bool isSafeToEvict() const;
+        ///< ESM reload loses nothing (mirrors the save-persistence criterion).
+#endif
+
         bool hasId(const ESM::RefId& id) const;
         ///< May return true for deleted IDs when in preload state. Will return false, if cell is
         /// unloaded.
@@ -351,6 +356,10 @@ namespace MWWorld
         MWWorld::Cell mCellVariant;
         State mState;
         bool mHasState;
+#ifdef __vita__
+        // Real state changes only (saves/water); never set by iteration.
+        bool mHasUnrecoverableState = false;
+#endif
         std::vector<ESM::RefId> mIds;
         float mWaterLevel;
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -12,6 +12,7 @@
 #include <osg/Geometry>
 #include <osg/MatrixTransform>
 #include "../vita/VitaInit.h"
+#include "../vita/VitaMemAudit.h"
 #include "../mwrender/vismask.hpp"
 #include "../mwrender/animation.hpp"
 #include "../mwmechanics/aipackage.hpp"
@@ -614,6 +615,21 @@ namespace MWWorld
 
             if (usedMB > budget - 20 && !s_cachesFlushed)
             {
+                // Snapshot what is resident before the flush wipes it.
+                Vita::auditWorldModel(mWorld.getWorldModel());
+                Vita::auditResourceCaches(mRendering.getResourceSystem());
+                {
+                    const std::size_t swept = mWorld.getWorldModel().evictSweptCellStores();
+                    const std::size_t loaded = mWorld.getWorldModel().evictInactiveLoadedCellStores(mActiveCells);
+                    if (swept + loaded > 0)
+                    {
+                        char evictBuf[112];
+                        snprintf(evictBuf, sizeof(evictBuf),
+                            "[VitaAudit] watchdog evicted %u swept + %u loaded cellstores", (unsigned)swept,
+                            (unsigned)loaded);
+                        Vita::breadcrumb(evictBuf);
+                    }
+                }
                 mRendering.flushUnrefQueueImmediate();
                 mRendering.getResourceSystem()->clearCache();
                 // Static caches that bypass OSG expiry; cleared explicitly.
@@ -2233,6 +2249,10 @@ namespace MWWorld
             flushPendingDemotion(mPendingDemotions.front().cell);
             loadingListener->increaseProgress(1);
         }
+
+        // Eviction is pressure-only; evicting here re-scans ESM from disk.
+        Vita::auditWorldModel(mWorld.getWorldModel());
+        Vita::auditResourceCaches(mRendering.getResourceSystem());
 #endif
 
         if (changeEvent)
@@ -2641,6 +2661,10 @@ namespace MWWorld
             flushPendingDemotion(mPendingDemotions.front().cell);
             loadingListener->increaseProgress(1);
         }
+
+        // Pressure-only eviction — see changeCellGrid.
+        Vita::auditWorldModel(mWorld.getWorldModel());
+        Vita::auditResourceCaches(mRendering.getResourceSystem());
 #endif
 
         if (useFading)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -5,6 +5,7 @@
 
 #ifdef __vita__
 #include "../vita/VitaInit.h"
+#include "../vita/VitaMemAudit.h"
 #define VITA_CRUMB(msg) Vita::breadcrumb(msg)
 #else
 #define VITA_CRUMB(msg)
@@ -286,14 +287,24 @@ namespace MWWorld
         mContentFiles = contentFiles;
         mESMVersions.resize(mContentFiles.size(), -1);
 
+#ifdef __vita__
+        vitaMemBreadcrumb("[VitaAudit] before ESM content load");
+#endif
         loadContentFiles(fileCollections, contentFiles, encoder, listener);
         loadGroundcoverFiles(fileCollections, groundcoverFiles, encoder, listener);
+#ifdef __vita__
+        vitaMemBreadcrumb("[VitaAudit] after ESM content load");
+#endif
 
         fillGlobalVariables();
 
         mStore.setUp();
         mStore.validateRecords(mReaders);
         mStore.movePlayerRecord();
+#ifdef __vita__
+        vitaMemBreadcrumb("[VitaAudit] after ESMStore setUp");
+        Vita::auditDialogueStore(mStore);
+#endif
 
         mSwimHeightScale = mStore.get<ESM::GameSetting>().find("fSwimHeightScale")->mValue.getFloat();
     }

--- a/apps/openmw/mwworld/worldmodel.cpp
+++ b/apps/openmw/mwworld/worldmodel.cpp
@@ -4,6 +4,9 @@
 #include <cassert>
 #include <optional>
 #include <stdexcept>
+#ifdef __vita__
+#include <unordered_set>
+#endif
 
 #include <components/debug/debuglog.hpp>
 #include <components/esm/defs.hpp>
@@ -22,6 +25,10 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/luamanager.hpp"
+
+#ifdef __vita__
+#include "../vita/VitaInit.h"
+#endif
 
 namespace MWWorld
 {
@@ -391,31 +398,93 @@ MWWorld::Ptr MWWorld::WorldModel::getPtrByRefId(const ESM::RefId& name)
     // Now try the other cells
     const MWWorld::Store<ESM::Cell>& cells = mStore.get<ESM::Cell>();
 
-    for (auto iter = cells.extBegin(); iter != cells.extEnd(); ++iter)
+    const Ptr found = [&] {
+        for (auto iter = cells.extBegin(); iter != cells.extEnd(); ++iter)
+        {
+            if (mCells.contains(iter->mId))
+                continue;
+
+            Ptr ptr = getPtrAndCache(name, insertCellStore(*iter));
+
+            if (!ptr.isEmpty())
+                return ptr;
+        }
+
+        for (auto iter = cells.intBegin(); iter != cells.intEnd(); ++iter)
+        {
+            if (mCells.contains(iter->mId))
+                continue;
+
+            Ptr ptr = getPtrAndCache(name, insertCellStore(*iter));
+
+            if (!ptr.isEmpty())
+                return ptr;
+        }
+
+        // giving up
+        return Ptr();
+    }();
+
+#ifdef __vita__
+    // Sweep pins stores; the memory watchdog evicts them under pressure.
     {
-        if (mCells.contains(iter->mId))
-            continue;
-
-        Ptr ptr = getPtrAndCache(name, insertCellStore(*iter));
-
-        if (!ptr.isEmpty())
-            return ptr;
+        char buf[160];
+        snprintf(buf, sizeof(buf), "[VitaAudit] getPtrByRefId('%s') found=%d, cellstores now %u",
+            name.toDebugString().c_str(), found.isEmpty() ? 0 : 1, (unsigned)mCells.size());
+        vitaMemBreadcrumb(buf);
     }
+#endif
 
-    for (auto iter = cells.intBegin(); iter != cells.intEnd(); ++iter)
-    {
-        if (mCells.contains(iter->mId))
-            continue;
-
-        Ptr ptr = getPtrAndCache(name, insertCellStore(*iter));
-
-        if (!ptr.isEmpty())
-            return ptr;
-    }
-
-    // giving up
-    return Ptr();
+    return found;
 }
+
+#ifdef __vita__
+std::size_t MWWorld::WorldModel::evictSweptCellStores()
+{
+    std::unordered_set<const CellStore*> toEvict;
+    for (auto& [id, store] : mCells)
+    {
+        if (store.getState() == CellStore::State_Loaded || store.hasState())
+            continue;
+        toEvict.insert(&store);
+    }
+    // Anything the Ptr cache references stays.
+    for (const auto& [cachedId, cachedCell] : mIdCache)
+        toEvict.erase(cachedCell);
+
+    if (toEvict.empty())
+        return 0;
+
+    // Erase by pointer identity to keep the indices consistent.
+    std::erase_if(mInteriors, [&](const auto& entry) { return toEvict.count(entry.second) > 0; });
+    std::erase_if(mExteriors, [&](const auto& entry) { return toEvict.count(entry.second) > 0; });
+    return std::erase_if(mCells, [&](auto& entry) { return toEvict.count(&entry.second) > 0; });
+}
+
+std::size_t MWWorld::WorldModel::evictInactiveLoadedCellStores(const std::set<CellStore*, std::less<>>& activeCells)
+{
+    std::unordered_set<const CellStore*> toEvict;
+    for (auto& [id, store] : mCells)
+    {
+        if (activeCells.count(&store) > 0)
+            continue;
+        // PtrRegistry self-cleans via ~LiveCellRefBase.
+        if (!store.isSafeToEvict())
+            continue;
+        toEvict.insert(&store);
+    }
+    // Ptr-cached cells stay resident.
+    for (const auto& [cachedId, cachedCell] : mIdCache)
+        toEvict.erase(cachedCell);
+
+    if (toEvict.empty())
+        return 0;
+
+    std::erase_if(mInteriors, [&](const auto& entry) { return toEvict.count(entry.second) > 0; });
+    std::erase_if(mExteriors, [&](const auto& entry) { return toEvict.count(entry.second) > 0; });
+    return std::erase_if(mCells, [&](auto& entry) { return toEvict.count(&entry.second) > 0; });
+}
+#endif
 
 void MWWorld::WorldModel::getExteriorPtrs(const ESM::RefId& name, std::vector<MWWorld::Ptr>& out)
 {
@@ -429,6 +498,16 @@ void MWWorld::WorldModel::getExteriorPtrs(const ESM::RefId& name, std::vector<MW
         if (!ptr.isEmpty())
             out.push_back(ptr);
     }
+
+#ifdef __vita__
+    // Full-world sweep; eviction deferred to the watchdog.
+    {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "[VitaAudit] getExteriorPtrs('%s') matches=%u, cellstores now %u",
+            name.toDebugString().c_str(), (unsigned)out.size(), (unsigned)mCells.size());
+        vitaMemBreadcrumb(buf);
+    }
+#endif
 }
 
 std::vector<MWWorld::Ptr> MWWorld::WorldModel::getAll(const ESM::RefId& id)

--- a/apps/openmw/mwworld/worldmodel.hpp
+++ b/apps/openmw/mwworld/worldmodel.hpp
@@ -3,6 +3,9 @@
 
 #include <list>
 #include <map>
+#ifdef __vita__
+#include <set>
+#endif
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -89,6 +92,20 @@ namespace MWWorld
             for (auto& [_, store] : mCells)
                 fn(store);
         }
+
+#ifdef __vita__
+        /// Destroy CellStores materialized by all-cell ID sweeps (getPtrByRefId /
+        /// getExteriorPtrs): preloaded or unloaded, no game state, not in the Ptr
+        /// cache. They are recreated on demand; keeping them pins an mIds vector
+        /// for every cell in the game. Returns the number evicted.
+        std::size_t evictSweptCellStores();
+
+        /// Destroy fully-loaded CellStores that were materialized by ID lookups
+        /// but never activated: not in \a activeCells, no game state, not in the
+        /// Ptr cache. Their LiveCellRefs are recreated on demand. Measured: the
+        /// new-game targeted-script burst pins ~60 loaded cells / ~11k refs.
+        std::size_t evictInactiveLoadedCellStores(const std::set<CellStore*, std::less<>>& activeCells);
+#endif
 
         /// Get all Ptrs referencing \a name in exterior cells
         /// @note Due to the current implementation of getPtr this only supports one Ptr per cell.

--- a/apps/openmw/vita/VitaInit.cpp
+++ b/apps/openmw/vita/VitaInit.cpp
@@ -1218,7 +1218,7 @@ namespace Vita
             0,
             0,
             SCE_GXM_MULTISAMPLE_NONE);
-        vglUseVram(GL_TRUE);
+        // vglUseVram removed upstream; VRAM-first is now the default.
         // fp16 in fragment shaders — SGX543 fp16 is full-rate, fp32 half-rate.
         vglUseLowPrecision(GL_TRUE);
         // SHARK_OPT_UNSAFE: most aggressive ALU rewrites; HAVE_SHADER_CACHE=1 amortises compile.

--- a/apps/openmw/vita/VitaMemAudit.cpp
+++ b/apps/openmw/vita/VitaMemAudit.cpp
@@ -1,0 +1,223 @@
+#ifdef __vita__
+
+#include "VitaMemAudit.h"
+#include "VitaInit.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include <psp2/kernel/clib.h>
+
+#include <osg/Geometry>
+#include <osg/Image>
+#include <osg/NodeVisitor>
+
+#include <components/esm3/loaddial.hpp>
+#include <components/esm3/loadinfo.hpp>
+#include <components/esm3/loadland.hpp>
+#include <components/esm3/loadscpt.hpp>
+#include <components/resource/imagemanager.hpp>
+#include <components/resource/keyframemanager.hpp>
+#include <components/resource/objectcache.hpp>
+#include <components/resource/resourcesystem.hpp>
+#include <components/resource/scenemanager.hpp>
+
+#include "../mwworld/cellstore.hpp"
+#include "../mwworld/esmstore.hpp"
+#include "../mwworld/worldmodel.hpp"
+
+namespace
+{
+    void auditLog(const char* buf)
+    {
+        sceClibPrintf("%s\n", buf);
+        vitaMemBreadcrumb(buf);
+    }
+
+    // String heap bytes beyond SSO (newlib SSO = 15).
+    size_t strHeapBytes(const std::string& s)
+    {
+        return s.capacity() > 15 ? s.capacity() + 1 : 0;
+    }
+
+    // malloc + std::list node overhead.
+    constexpr size_t kListNodeOverhead = 2 * sizeof(void*) + 8;
+
+    size_t dialInfoBytes(const ESM::DialInfo& info)
+    {
+        size_t bytes = sizeof(ESM::DialInfo) + kListNodeOverhead;
+        bytes += strHeapBytes(info.mSound);
+        bytes += strHeapBytes(info.mResponse);
+        bytes += strHeapBytes(info.mResultScript);
+        bytes += info.mSelects.capacity() * sizeof(ESM::DialogueCondition);
+        for (const auto& select : info.mSelects)
+            bytes += strHeapBytes(select.mVariable);
+        return bytes;
+    }
+
+    // Geometry bytes under a node; textures counted by the image audit.
+    class GeometryBytesVisitor : public osg::NodeVisitor
+    {
+    public:
+        GeometryBytesVisitor()
+            : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
+        {
+        }
+
+        void apply(osg::Drawable& drawable) override
+        {
+            if (const osg::Geometry* geom = drawable.asGeometry())
+            {
+                addArray(geom->getVertexArray());
+                addArray(geom->getNormalArray());
+                addArray(geom->getColorArray());
+                addArray(geom->getSecondaryColorArray());
+                addArray(geom->getFogCoordArray());
+                for (const auto& tc : geom->getTexCoordArrayList())
+                    addArray(tc.get());
+                for (const auto& va : geom->getVertexAttribArrayList())
+                    addArray(va.get());
+                for (const auto& ps : geom->getPrimitiveSetList())
+                    if (ps)
+                        mBytes += ps->getTotalDataSize();
+            }
+            traverse(drawable);
+        }
+
+        size_t mBytes = 0;
+
+    private:
+        void addArray(const osg::Array* array)
+        {
+            if (array)
+                mBytes += array->getTotalDataSize();
+        }
+    };
+}
+
+namespace Vita
+{
+    void auditDialogueStore(const MWWorld::ESMStore& store)
+    {
+        const auto& dialogues = store.get<ESM::Dialogue>();
+
+        size_t topics = 0;
+        size_t infos = 0;
+        size_t liveBytes = 0; // Dialogue::mInfo — the list actually used at runtime
+        size_t dupBytes = 0; // InfoOrder::mOrderedInfo — load-order copy never freed
+
+        for (auto it = dialogues.begin(); it != dialogues.end(); ++it)
+        {
+            const ESM::Dialogue& dial = *it;
+            ++topics;
+            liveBytes += sizeof(ESM::Dialogue) + strHeapBytes(dial.mStringId);
+            for (const ESM::DialInfo& info : dial.mInfo)
+            {
+                ++infos;
+                liveBytes += dialInfoBytes(info);
+            }
+            for (const ESM::DialInfo& info : dial.mInfoOrder.getOrderedInfo())
+                dupBytes += dialInfoBytes(info);
+        }
+
+        char buf[256];
+        snprintf(buf, sizeof(buf),
+            "[VitaAudit] dialogue: %u topics, %u infos, live=%uKB, infoOrderDup=%uKB, total=%uMB",
+            (unsigned)topics, (unsigned)infos, (unsigned)(liveBytes / 1024), (unsigned)(dupBytes / 1024),
+            (unsigned)((liveBytes + dupBytes) / (1024 * 1024)));
+        auditLog(buf);
+
+        // OpenMW recompiles from source; vanilla bytecode is dead weight.
+        const auto& scripts = store.get<ESM::Script>();
+        size_t scriptCount = 0;
+        size_t textBytes = 0;
+        size_t vanillaBytes = 0;
+        size_t varBytes = 0;
+        for (auto it = scripts.begin(); it != scripts.end(); ++it)
+        {
+            ++scriptCount;
+            textBytes += strHeapBytes(it->mScriptText);
+            vanillaBytes += it->mScriptData.capacity();
+            for (const auto& var : it->mVarNames)
+                varBytes += sizeof(std::string) + strHeapBytes(var);
+        }
+        snprintf(buf, sizeof(buf),
+            "[VitaAudit] scripts: %u records, sourceText=%uKB, vanillaBytecode=%uKB (unused), varNames=%uKB",
+            (unsigned)scriptCount, (unsigned)(textBytes / 1024), (unsigned)(vanillaBytes / 1024),
+            (unsigned)(varBytes / 1024));
+        auditLog(buf);
+
+        snprintf(buf, sizeof(buf), "[VitaAudit] store counts: cells=%u, lands=%u",
+            (unsigned)store.get<ESM::Cell>().getSize(), (unsigned)store.get<ESM::Land>().getSize());
+        auditLog(buf);
+    }
+
+    void auditWorldModel(MWWorld::WorldModel& worldModel)
+    {
+        size_t total = 0;
+        size_t loaded = 0;
+        size_t preloaded = 0;
+        size_t refs = 0;
+
+        worldModel.forEachLoadedCellStore([&](MWWorld::CellStore& cell) {
+            ++total;
+            switch (cell.getState())
+            {
+                case MWWorld::CellStore::State_Loaded:
+                    ++loaded;
+                    refs += cell.count();
+                    break;
+                case MWWorld::CellStore::State_Preloaded:
+                    ++preloaded;
+                    break;
+                default:
+                    break;
+            }
+        });
+
+        char buf[224];
+        snprintf(buf, sizeof(buf),
+            "[VitaAudit] worldmodel: %u cellstores (%u loaded, %u preloaded), %u live refs resident",
+            (unsigned)total, (unsigned)loaded, (unsigned)preloaded, (unsigned)refs);
+        auditLog(buf);
+    }
+
+    void auditResourceCaches(Resource::ResourceSystem* resourceSystem)
+    {
+        if (!resourceSystem)
+            return;
+
+        size_t imageCount = 0;
+        size_t imageBytes = 0;
+        resourceSystem->getImageManager()->getObjectCache()->call([&](const auto&, osg::Object* obj) {
+            if (const osg::Image* image = dynamic_cast<osg::Image*>(obj))
+            {
+                ++imageCount;
+                imageBytes += image->getTotalSizeInBytesIncludingMipmaps();
+            }
+        });
+
+        size_t nodeCount = 0;
+        GeometryBytesVisitor geomBytes;
+        resourceSystem->getSceneManager()->getObjectCache()->call([&](const auto&, osg::Object* obj) {
+            if (osg::Node* node = dynamic_cast<osg::Node*>(obj))
+            {
+                ++nodeCount;
+                node->accept(geomBytes);
+            }
+        });
+
+        size_t keyframeCount = 0;
+        resourceSystem->getKeyframeManager()->getObjectCache()->call(
+            [&](const auto&, osg::Object*) { ++keyframeCount; });
+
+        char buf[256];
+        snprintf(buf, sizeof(buf),
+            "[VitaAudit] caches: images=%u (%uKB), sceneTemplates=%u (geom %uKB), keyframes=%u",
+            (unsigned)imageCount, (unsigned)(imageBytes / 1024), (unsigned)nodeCount,
+            (unsigned)(geomBytes.mBytes / 1024), (unsigned)keyframeCount);
+        auditLog(buf);
+    }
+}
+
+#endif // __vita__

--- a/apps/openmw/vita/VitaMemAudit.h
+++ b/apps/openmw/vita/VitaMemAudit.h
@@ -1,0 +1,33 @@
+#ifndef OPENMW_VITA_MEMAUDIT_H
+#define OPENMW_VITA_MEMAUDIT_H
+
+#ifdef __vita__
+
+namespace MWWorld
+{
+    class ESMStore;
+    class WorldModel;
+}
+
+namespace Resource
+{
+    class ResourceSystem;
+}
+
+namespace Vita
+{
+    // Heap audits: [VitaAudit] lines to boot.log + sceClibPrintf.
+
+    // Dialogue store byte census; call after ESMStore::setUp.
+    void auditDialogueStore(const MWWorld::ESMStore& store);
+
+    // CellStore residency and pinned LiveCellRef counts.
+    void auditWorldModel(MWWorld::WorldModel& worldModel);
+
+    // Resource cache entry counts and byte estimates.
+    void auditResourceCaches(Resource::ResourceSystem* resourceSystem);
+}
+
+#endif // __vita__
+
+#endif

--- a/apps/openmw/vita/settings.cfg
+++ b/apps/openmw/vita/settings.cfg
@@ -119,6 +119,8 @@ anisotropy = 0
 # off:         no cap (full resolution)
 # Restart required to take effect.
 vita texture detail = balanced
+# Keep DXT compressed on GPU (needs openmw-pin vitaGL). Restart required.
+vita keep compressed textures = true
 
 [Sound]
 buffer cache min = 1

--- a/components/esm3/infoorder.hpp
+++ b/components/esm3/infoorder.hpp
@@ -86,7 +86,13 @@ namespace ESM
 
         void extractOrderedInfo(std::list<T>& info)
         {
+#ifdef __vita__
+            // Move halves dialogue RAM; Dialogue::setUp guards re-runs.
+            info = std::move(mOrderedInfo);
+            mOrderedInfo.clear();
+#else
             info = mOrderedInfo;
+#endif
             mInfoPositions.clear();
         }
 

--- a/components/esm3/loaddial.cpp
+++ b/components/esm3/loaddial.cpp
@@ -117,6 +117,11 @@ namespace ESM
 
     void Dialogue::setUp()
     {
+#ifdef __vita__
+        // Vita extract is destructive; skip repeat setUp (save load).
+        if (mInfoOrder.getOrderedInfo().empty() && !mInfo.empty())
+            return;
+#endif
         mInfoOrder.removeDeleted();
         mInfoOrder.extractOrderedInfo(mInfo);
     }

--- a/components/files/constrainedfilestreambuf.hpp
+++ b/components/files/constrainedfilestreambuf.hpp
@@ -25,7 +25,8 @@ namespace Files
         std::size_t mSize;
         Platform::File::ScopedHandle mFile;
 #ifdef __vita__
-        char mBuffer[32768]{ 0 };
+        // 64K: fewer sceIo calls; bigger regresses seek-heavy ESM reads.
+        char mBuffer[65536]{ 0 };
 #else
         char mBuffer[8192]{ 0 };
 #endif

--- a/components/resource/imagemanager.cpp
+++ b/components/resource/imagemanager.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <osgDB/Registry>
 
 #include <components/debug/debuglog.hpp>
@@ -288,6 +289,48 @@ namespace
             }
         }
     }
+
+    inline bool isPowerOfTwo(int x)
+    {
+        return x > 0 && (x & (x - 1)) == 0;
+    }
+
+    // Cap compressed images by discarding top mips (stays DXT).
+    osg::ref_ptr<osg::Image> dropCompressedTopMips(osg::ref_ptr<osg::Image> image, int maxEdge)
+    {
+        const unsigned int levels = image->getNumMipmapLevels();
+        int s = image->s(), t = image->t();
+        unsigned int drop = 0;
+        // Keep base >= 4px for DXT block alignment.
+        while ((s > maxEdge || t > maxEdge) && drop + 1 < levels && s > 4 && t > 4)
+        {
+            s >>= 1;
+            t >>= 1;
+            ++drop;
+        }
+        if (drop == 0)
+            return image;
+
+        // offsets[i] = byte offset of level i+1.
+        const osg::Image::MipmapDataType& offsets = image->getMipmapLevels();
+        const unsigned int newBase = offsets[drop - 1];
+        const unsigned int newSize = image->getTotalSizeInBytesIncludingMipmaps() - newBase;
+
+        unsigned char* buf = new unsigned char[newSize];
+        std::memcpy(buf, image->data() + newBase, newSize);
+
+        osg::Image::MipmapDataType newOffsets;
+        newOffsets.reserve(levels - drop - 1);
+        for (unsigned int i = drop; i + 1 < levels; ++i)
+            newOffsets.push_back(offsets[i] - newBase);
+
+        osg::ref_ptr<osg::Image> out = new osg::Image;
+        out->setFileName(image->getFileName());
+        out->setImage(s, t, 1, image->getInternalTextureFormat(), image->getPixelFormat(), image->getDataType(),
+            buf, osg::Image::USE_NEW_DELETE, image->getPacking());
+        out->setMipmapLevels(newOffsets);
+        return out;
+    }
 #endif
 
 }
@@ -397,10 +440,7 @@ namespace Resource
             osg::ref_ptr<osg::Image> image = result.getImage();
 
 #ifdef __vita__
-            // Decompress DXT textures to RGBA on Vita.
-            // vitaGL's glCompressedTexImage2D has partial DXT support and our
-            // glCompressedTexSubImage2D is a no-op stub — some textures render
-            // as solid green (uninitialized VRAM). CPU decompression is safe.
+            // Keep DXT compressed (GXM-native); subload path sealed in vita-compat.patch.
             if (image->isCompressed())
             {
                 GLenum fmt = image->getPixelFormat();
@@ -409,22 +449,29 @@ namespace Resource
                            || fmt == GL_COMPRESSED_RGBA_S3TC_DXT3_EXT
                            || fmt == GL_COMPRESSED_RGBA_S3TC_DXT5_EXT);
 
-                osg::ref_ptr<osg::Image> newImage = new osg::Image;
-                newImage->setFileName(image->getFileName());
-                GLenum outFmt = image->isImageTranslucent() ? GL_RGBA : GL_RGB;
-                newImage->allocateImage(image->s(), image->t(), image->r(), outFmt, GL_UNSIGNED_BYTE);
+                const bool keepCompressed = Settings::general().mVitaKeepCompressedTextures && isDXT
+                    && image->r() == 1 && image->getNumMipmapLevels() > 1 && isPowerOfTwo(image->s())
+                    && isPowerOfTwo(image->t()) && image->isDataContiguous();
 
-                if (isDXT && image->r() == 1)
-                    decompressDXT(image.get(), newImage.get());
-                else
+                if (!keepCompressed)
                 {
-                    // Fallback for non-DXT compressed or 3D textures
-                    for (int s = 0; s < image->s(); ++s)
-                        for (int t = 0; t < image->t(); ++t)
-                            for (int r = 0; r < image->r(); ++r)
-                                newImage->setColor(image->getColor(s, t, r), s, t, r);
+                    osg::ref_ptr<osg::Image> newImage = new osg::Image;
+                    newImage->setFileName(image->getFileName());
+                    GLenum outFmt = image->isImageTranslucent() ? GL_RGBA : GL_RGB;
+                    newImage->allocateImage(image->s(), image->t(), image->r(), outFmt, GL_UNSIGNED_BYTE);
+
+                    if (isDXT && image->r() == 1)
+                        decompressDXT(image.get(), newImage.get());
+                    else
+                    {
+                        // Fallback for non-DXT compressed or 3D textures
+                        for (int s = 0; s < image->s(); ++s)
+                            for (int t = 0; t < image->t(); ++t)
+                                for (int r = 0; r < image->r(); ++r)
+                                    newImage->setColor(image->getColor(s, t, r), s, t, r);
+                    }
+                    image = newImage;
                 }
-                image = newImage;
             }
 
             // Cap world textures; skip UI/normal/spec; atlases get a higher
@@ -489,17 +536,24 @@ namespace Resource
                 }
 
                 const int maxEdge = isAtlas ? atlasCap : worldCap;
-                if (downsampleEnabled && !isUI && !isNormalSpec && !image->isCompressed()
-                    && image->s() > 1 && image->t() > 1)
+                if (downsampleEnabled && !isUI && !isNormalSpec && image->s() > 1 && image->t() > 1)
                 {
-                    int s = image->s(), t = image->t();
-                    while ((s > maxEdge || t > maxEdge) && s > 1 && t > 1)
+                    if (image->isCompressed())
                     {
-                        s = std::max(s / 2, 1);
-                        t = std::max(t / 2, 1);
+                        // Cap via mip drop, no rescale.
+                        image = dropCompressedTopMips(image, maxEdge);
                     }
-                    if (s != image->s() || t != image->t())
-                        image->scaleImage(s, t, image->r());
+                    else
+                    {
+                        int s = image->s(), t = image->t();
+                        while ((s > maxEdge || t > maxEdge) && s > 1 && t > 1)
+                        {
+                            s = std::max(s / 2, 1);
+                            t = std::max(t / 2, 1);
+                        }
+                        if (s != image->s() || t != image->t())
+                            image->scaleImage(s, t, image->r());
+                    }
                 }
             }
 #endif

--- a/components/resource/resourcemanager.hpp
+++ b/components/resource/resourcemanager.hpp
@@ -56,6 +56,9 @@ namespace Resource
         /// Clear all cache entries.
         void clearCache() override { mCache->clear(); }
 
+        /// Direct cache access for diagnostics/statistics (e.g. Vita memory audit).
+        CacheType* getObjectCache() { return mCache.get(); }
+
         /// How long to keep objects in cache after no longer being referenced.
         void setExpiryDelay(double expiryDelay) final { mExpiryDelay = expiryDelay; }
         double getExpiryDelay() const { return mExpiryDelay; }

--- a/components/settings/categories/general.hpp
+++ b/components/settings/categories/general.hpp
@@ -34,6 +34,8 @@ namespace Settings
         // the values the Vita port shipped with before the setting existed.
         SettingValue<std::string> mVitaTextureDetail{ mIndex, "General", "vita texture detail",
             makeEnumSanitizerString({ "performance", "balanced", "high", "off" }) };
+        // Vita: keep DXT compressed on GPU; false restores decompress path.
+        SettingValue<bool> mVitaKeepCompressedTextures{ mIndex, "General", "vita keep compressed textures", true };
         SettingValue<bool> mNotifyOnSavedScreenshot{ mIndex, "General", "notify on saved screenshot" };
         SettingValue<std::vector<std::string>> mPreferredLocales{ mIndex, "General", "preferred locales" };
         SettingValue<bool> mGmstOverridesL10n{ mIndex, "General", "gmst overrides l10n" };

--- a/patches/osg/vita-compat.patch
+++ b/patches/osg/vita-compat.patch
@@ -6,6 +6,9 @@ Vita compatibility patch for OpenSceneGraph (OSG):
   - drop glGetRenderbufferParameteriv from isFrameBufferObjectSupported
     check (vitaGL never exposes it, which otherwise disables all FBO RTT)
   - cast RefMatrixf to Matrixd for ambiguous operator!= under OSG_USE_FLOAT_MATRIX
+  - refuse texture subloading for compressed images (vitaGL lacks
+    glCompressedTexSubImage2D; forces the glCompressedTexImage2D full-upload
+    path so DXT textures can stay compressed on the GPU)
 
 --- a/src/osgDB/FileUtils.cpp
 +++ b/src/osgDB/FileUtils.cpp
@@ -84,3 +87,22 @@ Vita compatibility patch for OpenSceneGraph (OSG):
 
          osg::Polytope polytope;
  #if 1
+--- a/src/osg/Image.cpp
++++ b/src/osg/Image.cpp
+@@ -1959,6 +1959,16 @@
+ 
+ bool Image::supportsTextureSubloading() const
+ {
++#if defined(__vita__)
++    // vitaGL has no glCompressedTexSubImage2D (the app links a no-op stub),
++    // so a recycled texture object subloading a compressed image leaves
++    // uninitialized VRAM (solid green). Refuse subloading for compressed
++    // images entirely: Texture2D::apply then re-specifies via the full
++    // glCompressedTexImage2D path, which vitaGL implements natively for
++    // DXT1/3/5.
++    if (isCompressed())
++        return false;
++#endif
+     switch(_internalTextureFormat)
+     {
+         case GL_ETC1_RGB8_OES:


### PR DESCRIPTION
  - Keep DXT textures compressed on GPU
  - Mip-drop for texture size caps
  - OSG patch: no compressed subloads
  - Watchdog CellStore eviction (save-criterion safety)
  - InfoOrder move fix (halves dialogue RAM)
  - 64KB read buffers
  - VitaMemAudit heap instrumentation
  - Remove stale vglUseVram call